### PR TITLE
Fixed render_old exit crash

### DIFF
--- a/render_old.c
+++ b/render_old.c
@@ -149,6 +149,8 @@ void render_layer(const char *tilepath, const char *name)
     int z;
 
     for (z=minZoom; z<=maxZoom; z++) {
+		if (verbose)
+			printf("Rendering zoom %d\n", z);				
         char path[PATH_MAX];
         snprintf(path, PATH_MAX, "%s/%s/%d", tilepath, name, z);
         descend(path);


### PR DESCRIPTION
Fixed the crash when freeing tile_dir when no map style file has been specified.
