### PR TITLE
Fix typos in render_list man page

### DIFF
--- a/docs/render_list.1
+++ b/docs/render_list.1
@@ -1,4 +1,4 @@
-.TH RENDER_LIST 1 "Mar 28, 2013"
+.TH RENDER_LIST 1 "Apr 25, 2013"
 .\" Please adjust this date whenever revising the manpage.
 .SH NAME
 render_list \- renders a list of map tiles by sending requests to a rendering daemon.
@@ -8,7 +8,7 @@ render_list \- renders a list of map tiles by sending requests to a rendering da
 .br
 .SH DESCRIPTION
 This manual page documents briefly the
-.B render_lis
+.B render_list
 command.
 .PP
 .B render_list
@@ -19,6 +19,6 @@ is a helper utility that takes a list of map tiles from stdin and sends the requ
 .BR mod_tile (1).
 .br
 .SH AUTHOR
-render_expire was written by OpenStreetMap project members.
+render_list was written by OpenStreetMap project members.
 .PP
 This manual page was written by OpenStreetMap authors.


### PR DESCRIPTION
A couple of typos of the program name
