### PR TITLE
Add 'null' storage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,7 +5,7 @@ ACLOCAL_AMFLAGS = -I m4
 
 AM_CPPFLAGS = $(FT2_CFLAGS) $(PTHREAD_CFLAGS) $(BOOST_CPPFLAGS) $(ICU_CPPFLAGS) $(CAIRO_CFLAGS) $(CAIROMM_CFLAGS)
 
-STORE_SOURCES = store.c store_file.c store_file_utils.c store_memcached.c store_rados.c store_ro_http_proxy.c store_ro_composite.c
+STORE_SOURCES = store.c store_file.c store_file_utils.c store_memcached.c store_rados.c store_ro_http_proxy.c store_ro_composite.c store_null.c
 STORE_LDFLAGS = $(LIBMEMCACHED_LDFLAGS) $(LIBRADOS_LDFLAGS) $(LIBCURL) $(CAIRO_LIBS)
 
 bin_PROGRAMS = renderd render_expired render_list render_speedtest render_old gen_tile_test

--- a/store.c
+++ b/store.c
@@ -21,6 +21,7 @@
 #include "store_rados.h"
 #include "store_ro_http_proxy.h"
 #include "store_ro_composite.h"
+#include "store_null.h"
 
 //TODO: Make this function handle different logging backends, depending on if on compiles it from apache or something else
 void log_message(int log_lvl, const char *format, ...) {
@@ -95,6 +96,11 @@ struct storage_backend * init_storage_backend(const char * options) {
     if (strstr(options,"composite:{") == options) {
         log_message(STORE_LOGLVL_DEBUG, "init_storage_backend: initialising ro_composite storage backend at: %s", options);
         store = init_storage_ro_composite(options);
+        return store;
+    }
+    if (strstr(options,"null://") == options) {
+        log_message(STORE_LOGLVL_DEBUG, "init_storage_backend: initialising null storage backend at: %s", options);
+        store = init_storage_null();
         return store;
     }
 

--- a/store_null.c
+++ b/store_null.c
@@ -1,0 +1,77 @@
+#include "store_null.h"
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <limits.h>
+
+static int tile_read(struct storage_backend * store, 
+		     const char *xmlconfig, 
+		     int x, int y, int z, 
+		     char *buf, size_t sz, 
+		     int * compressed, char * err_msg) {
+   snprintf(err_msg, PATH_MAX - 1, "Cannot read from NULL storage.");
+   return -1;
+}
+
+static struct stat_info tile_stat(struct storage_backend * store, 
+				  const char *xmlconfig, 
+				  int x, int y, int z) {
+   struct stat_info tile_stat;
+   tile_stat.size = -1;
+   tile_stat.atime = 0;
+   tile_stat.mtime = 0;
+   tile_stat.ctime = 0;
+   tile_stat.expired = 1;
+   return tile_stat;
+}
+
+static int metatile_write(struct storage_backend * store, 
+			  const char *xmlconfig, 
+			  int x, int y, int z, 
+			  const char *buf, int sz) {
+   // fake like we actually wrote the tile, but we didn't...
+   return sz;
+}
+
+static int metatile_delete(struct storage_backend * store, 
+			   const char *xmlconfig, 
+			   int x, int y, int z) {
+   return 0;
+}
+
+static int metatile_expire(struct storage_backend * store, 
+			   const char *xmlconfig, 
+			   int x, int y, int z) {
+   return 0;
+}
+
+static char * tile_storage_id(struct storage_backend * store, 
+			      const char *xmlconfig, 
+			      int x, int y, int z, 
+			      char * string) {
+   snprintf(string, PATH_MAX - 1, "null://");
+   return string;
+}
+
+static int close_storage(struct storage_backend * store) {
+   return 0;
+}
+
+struct storage_backend *init_storage_null() {
+   struct storage_backend *store = malloc(sizeof *store);
+   if (store == NULL) {
+      log_message(STORE_LOGLVL_ERR, "init_storage_null: Failed to allocate memory for storage backend");
+      return NULL;
+   }
+
+   store->storage_ctx = NULL;
+   store->tile_read = &tile_read;
+   store->tile_stat = &tile_stat;
+   store->metatile_write = &metatile_write;
+   store->metatile_delete = &metatile_delete;
+   store->metatile_expire = &metatile_expire;
+   store->tile_storage_id = &tile_storage_id;
+   store->close_storage = &close_storage;
+
+   return store;
+}

--- a/store_null.h
+++ b/store_null.h
@@ -1,0 +1,16 @@
+#ifndef STORE_NULL_H
+#define STORE_NULL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "store.h"
+
+   struct storage_backend * init_storage_null();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* STORE_NULL_H */


### PR DESCRIPTION
Added simple 'null' storage, which might be useful for benchmarking or testing. It doesn't store anything - but will respond with success to a write request and return a "not found" result to any read request.
