### PR TITLE
Change absolute URL in slippymap.html to a relative one

### DIFF
--- a/slippymap.html
+++ b/slippymap.html
@@ -41,7 +41,7 @@
             } );
  
             // This is the layer that uses the locally stored tiles
-            var newLayer = new OpenLayers.Layer.OSM("Local Tiles", "http://localhost/osm/${z}/${x}/${y}.png", {numZoomLevels: 19});
+            var newLayer = new OpenLayers.Layer.OSM("Local Tiles", "${z}/${x}/${y}.png", {numZoomLevels: 19});
             map.addLayer(newLayer);
 
             layerMapnik = new OpenLayers.Layer.OSM.Mapnik("Mapnik");


### PR DESCRIPTION
If we're browsing from a different machine localhost is the wrong hostname.
