### PR TITLE
Log start tile

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -80,6 +80,20 @@ void send_response(struct item *item, enum protoCmd rsp, int render_time) {
     }
 }
 
+void item_load(struct item *item, const struct protocol *req) {
+    char path[PATH_MAX];
+    struct stat buf;
+    xyz_to_meta(path, sizeof(path), HASH_PATH, req->xmlname, req->x, req->y, req->z);
+    if(!stat(path, &buf)) {
+	// save time of old tile
+	item->old_mtime=buf.st_mtime;
+    }
+    else {
+	// no tile
+	item->old_mtime=0;
+    }
+}
+
 enum protoCmd rx_request(const struct protocol *req, int fd)
 {
     struct protocol *reqnew;
@@ -113,6 +127,8 @@ enum protoCmd rx_request(const struct protocol *req, int fd)
     item->req = *req;
     item->duplicates = NULL;
     item->fd = (req->cmd == cmdDirty) ? FD_INVALID : fd;
+
+    item_load(item, req);
 
 #ifdef METATILE
     /* Round down request co-ordinates to the neareast N (should be a power of 2)

--- a/gen_tile.cpp
+++ b/gen_tile.cpp
@@ -586,15 +586,23 @@ void *render_thread(void * arg)
                             timeval tim;
                             gettimeofday(&tim, NULL);
                             long t1=tim.tv_sec*1000+(tim.tv_usec/1000);
-                            syslog(LOG_DEBUG, "DEBUG: START TILE %s %d %d-%d %d-%d",
-                                   req->xmlname, req->z, item->mx, item->mx+size-1, item->my, item->my+size-1);
+
+                            if(item->old_mtime==0)
+                                syslog(LOG_DEBUG, "DEBUG: START TILE %s %d %d-%d %d-%d, new metatile",
+                                       req->xmlname, req->z, item->mx, item->mx+size-1, item->my, item->my+size-1);
+                            else
+                                syslog(LOG_DEBUG, "DEBUG: START TILE %s %d %d-%d %d-%d, age %.3f days",
+                                       req->xmlname, req->z, item->mx, item->mx+size-1, item->my, item->my+size-1,
+                                   (tim.tv_sec-item->old_mtime)/86400.0);
 
                             ret = render(&(maps[i]), item->mx, item->my, req->z, tiles);
 
                             gettimeofday(&tim, NULL);
                             long t2=tim.tv_sec*1000+(tim.tv_usec/1000);
+
                             syslog(LOG_DEBUG, "DEBUG: DONE TILE %s %d %d-%d %d-%d in %.3lf seconds",
                                     req->xmlname, req->z, item->mx, item->mx+size-1, item->my, item->my+size-1, (t2 - t1)/1000.0);
+
                             render_time = t2 - t1;
 
                             if (ret == cmdDone) {

--- a/gen_tile.h
+++ b/gen_tile.h
@@ -20,6 +20,7 @@ struct item {
     int fd;
     struct item *duplicates;
     enum queueEnum inQueue;
+    time_t old_mtime;
 };
 
 //int render(Map &m, int x, int y, int z, const char *filename);


### PR DESCRIPTION
Write a "START TILE" message to syslog when starting to render. Also write age of old tile(s)/"new metatile" if it already exists - therefore add property "old_mtime" to struct protocol.
