### PR TITLE
Bleed

### DIFF
--- a/daemon.c
+++ b/daemon.c
@@ -745,6 +745,22 @@ int main(int argc, char **argv)
                 exit(7);
             }
 
+            sprintf(buffer, "%s:bleed_x", name);
+            char *ini_bleed_x = iniparser_getstring(ini, buffer, (char *) "0");
+            maps[iconf].bleed_x = atoi(ini_bleed_x);
+            if (maps[iconf].bleed_x < 0) {
+                fprintf(stderr, "Bleed X is invalid: %s\n", ini_bleed_x);
+                exit(7);
+            }
+
+            sprintf(buffer, "%s:bleed_y", name);
+            char *ini_bleed_y = iniparser_getstring(ini, buffer, (char *) "0");
+            maps[iconf].bleed_y = atoi(ini_bleed_y);
+            if (maps[iconf].bleed_y < 0) {
+                fprintf(stderr, "Bleed Y is invalid: %s\n", ini_bleed_y);
+                exit(7);
+            }
+
             sprintf(buffer, "%s:tiledir", name);
             char *ini_tiledir = iniparser_getstring(ini, buffer, (char *) config.tile_dir);
             if (strlen(ini_tiledir) >= (PATH_MAX - 1)) {

--- a/daemon.h
+++ b/daemon.h
@@ -36,6 +36,8 @@ typedef struct {
     char htcpip[PATH_MAX];
     char tile_dir[PATH_MAX];
     int tile_px_size;
+    int bleed_x;
+    int bleed_y;
 } xmlconfigitem;
 
 

--- a/gen_tile.cpp
+++ b/gen_tile.cpp
@@ -79,6 +79,8 @@ struct xmlmapconfig {
     char htcphost[PATH_MAX];
     int htcpsock;
     int tilesize;
+    int bleed_x;
+    int bleed_y;
     int ok;
     xmlmapconfig() :
         map(256,256) {}
@@ -427,10 +429,8 @@ static int check_xyz(int x, int y, int z, struct xmlmapconfig * map) {
 
 static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, metaTile &tiles)
 {
-    int px_bleed_x = 256;
-    int px_bleed_y = 128;
-    double bleed_x = (double)px_bleed_x / map->tilesize;
-    double bleed_y = (double)px_bleed_y / map->tilesize;
+    double bleed_x = (double)map->bleed_x / map->tilesize;
+    double bleed_y = (double)map->bleed_y / map->tilesize;
     int render_size_tx = MIN(METATILE, map->prj->aspect_x * (1 << z));
     int render_size_ty = MIN(METATILE, map->prj->aspect_y * (1 << z));
 
@@ -441,16 +441,16 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, meta
     syslog(LOG_DEBUG, "DEBUG: p0 %f %f p1 %f %f", p0x, p0y, p1x, p1y);
 
     mapnik::box2d<double> bbox(p0x, p0y, p1x,p1y);
-    map->map.resize(render_size_tx * map->tilesize + px_bleed_x * 2,
-                    render_size_ty * map->tilesize + px_bleed_y * 2);
+    map->map.resize(render_size_tx * map->tilesize + map->bleed_x * 2,
+                    render_size_ty * map->tilesize + map->bleed_y * 2);
     map->map.zoom_to_box(bbox);
     if (map->map.buffer_size() == 0) { // Only set buffer size if the buffer size isn't explicitly set in the mapnik stylesheet.
         map->map.set_buffer_size(128);
     }
     //m.zoom(size+1);
 
-    mapnik::image_32 buf(render_size_tx * map->tilesize + px_bleed_x * 2,
-                         render_size_ty * map->tilesize + px_bleed_y * 2);
+    mapnik::image_32 buf(render_size_tx * map->tilesize + map->bleed_x * 2,
+                         render_size_ty * map->tilesize + map->bleed_y * 2);
     try {
       mapnik::agg_renderer<mapnik::image_32> ren(map->map,buf);
       ren.apply();
@@ -465,8 +465,8 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, meta
     for (yy = 0; yy < render_size_ty; yy++) {
         for (xx = 0; xx < render_size_tx; xx++) {
             mapnik::image_view<mapnik::image_data_32> vw(
-                xx * map->tilesize + px_bleed_x,
-                yy * map->tilesize + px_bleed_y,
+                xx * map->tilesize + map->bleed_x,
+                yy * map->tilesize + map->bleed_y,
                 map->tilesize, map->tilesize, buf.data());
             tiles.set(xx, yy, save_to_string(vw, "png256"));
         }
@@ -540,7 +540,8 @@ void *render_thread(void * arg)
         strcpy(maps[iMaxConfigs].xmlfile, parentxmlconfig[iMaxConfigs].xmlfile);
         maps[iMaxConfigs].store = init_storage_backend(parentxmlconfig[iMaxConfigs].tile_dir);
         maps[iMaxConfigs].tilesize  = parentxmlconfig[iMaxConfigs].tile_px_size;
-
+        maps[iMaxConfigs].bleed_x = parentxmlconfig[iMaxConfigs].bleed_x;
+        maps[iMaxConfigs].bleed_y = parentxmlconfig[iMaxConfigs].bleed_y;
 
         if (maps[iMaxConfigs].store) {
             maps[iMaxConfigs].ok = 1;

--- a/renderd.conf
+++ b/renderd.conf
@@ -39,6 +39,12 @@ TILESIZE=256
 ;SERVER_ALIAS=http://localhost/
 ;CORS=http://www.openstreetmap.org
 
+;; Bleed defines an amount of pixels which will be rendered around the
+;; tile/metatile, which will be cut off after rendering. It helps to solve
+;; problems with labels near edges. Default: 0.
+;bleed_x=256
+;bleed_y=128
+
 ;[style2]
 ;URI=/osm_tiles2/
 ;TILEDIR=rados://tiles/etc/ceph/ceph.conf


### PR DESCRIPTION
When using TextSymbolizers with Placements, it may happen that labels for objects near the metatile edge are dissipated or duplicated as the Placement algorithm achieves different results for the left and right (or upper and lower) metatile. Here's an example from a project I'm working on right now:

![mod_tile_bleed_before](https://f.cloud.github.com/assets/249012/555115/d4865ee6-c3b7-11e2-9416-54de9e889ecc.png)

It's an overlay for public transportation routes based on OpenStreetMap data. The left part is a right-most tile of a meta tile, the right part a left-most tile of the adjacent meta tile. As you can see, the label "Franzensbrücke" is printed on both tiles. This happens for (almost) all objects which cross the boundary.

I solved this problem by introducing a ["bleed"](http://en.wikipedia.org/wiki/Bleed_%28printing%29): An area which will be rendered but trimmed when splitting the meta tile into its parts. You can configure the bleed for each map in renderd.conf (an amount of pixels, default: no bleed).

Here's an example with a bleed of 256px:
![mod_tile_bleed_256](https://f.cloud.github.com/assets/249012/555117/e7182b84-c3b7-11e2-95fa-7a14310ca92b.png)

You may choose to use a different bleed for the vertical and horizontal axis, as (in my example) the bleed depends on the extent of the labels. In the example above the labels are always horizontal texts, therefore horizontal bleed needs to be way larger.

Here's the example again with a horizontal bleed of 128px (which is apparently to small):
![mod_tile_bleed_128](https://f.cloud.github.com/assets/249012/555119/ebc441cc-c3b7-11e2-8cf9-846fdc0cff59.png)

I guess this is a nice addition to the features of mod_tile/renderd :-)
