### PR TITLE
Improve CORS support

### DIFF
--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -395,17 +395,19 @@ static int add_cors(request_rec *r, const char * cors) {
                                apr_psprintf(r->pool, "%s", "Origin"));
                 
             }
-            headers = apr_table_get(r->headers_in,"Access-Control-Request-Headers");
-            apr_table_setn(r->headers_out, "Access-Control-Allow-Headers",
-                           apr_psprintf(r->pool, "%s", headers));
-            if (headers) {
+            if (strcmp(r->method, "OPTIONS") == 0 &&
+                apr_table_get(r->headers_in, "Access-Control-Request-Method")) {
+                headers = apr_table_get(r->headers_in, "Access-Control-Request-Headers");
+                if (headers) {
+                    apr_table_setn(r->headers_out, "Access-Control-Allow-Headers",
+                                   apr_psprintf(r->pool, "%s", headers));
+                }
                 apr_table_setn(r->headers_out, "Access-Control-Max-Age",
                                apr_psprintf(r->pool, "%i", 604800));
-            }
-            //If this is an OPTIONS cors pre-flight request, no need to return the body as the actual request will follow
-            if (strcmp(r->method, "OPTIONS") == 0)
                 return OK;
-            else return DONE;
+            } else {
+                return DONE;
+            }
         } else {
             ap_log_rerror(APLOG_MARK, APLOG_INFO, 0, r, "Origin header (%s)is NOT allowed under the CORS policy(%s). Rejecting request", origin, cors);
             return HTTP_FORBIDDEN;


### PR DESCRIPTION
This will fix #39 and cleanup a few other things:
- Only treat OPTIONS as preflight if Access-Control-Request-Method  is set
- Only send Access-Control-Allow-Headers for preflight requests
- Don't send a bogus Access-Control-Allow-Headers value

There is a good flowchart at http://www.html5rocks.com/static/images/cors_server_flowchart.png showing how CORS should work on the server end.
