### PR TITLE
Don't try to install mod_tile.so using debian/libapache2-mod-tile.install

### DIFF
--- a/debian/libapache2-mod-tile.install
+++ b/debian/libapache2-mod-tile.install
@@ -1,4 +1,3 @@
-.libs/mod_tile.so /usr/lib/apache2/modules
 debian/tile.load /etc/apache2/mods-available
 debian/tileserver_site /etc/apache2/sites-available/
 readme.txt /usr/share/doc/libapache2-mod-tile


### PR DESCRIPTION
I tried to build a Debian package on Debian Wheezy, but this failed since mod_tile.so was not found in the expected location during the package build. I think that this was not working anymore since 273973e which moved the sources to a src/ directory in order to clean up the top level directory. However, debian/rules already contains calls to 'make' which install mod_tile.so to the correct location, so it's not even necessary to install it using debian/libapache2-mod-tile.install. This patch removes this line from libapache2-mod-tile.install which fixed the package build for me.
