### PR TITLE
Update renderd.conf mapnik paths to default ubuntu paths with mapnik PPA

### DIFF
--- a/renderd.conf
+++ b/renderd.conf
@@ -19,8 +19,8 @@ stats_file=/var/run/renderd/renderd.stats
 ;stats_file=/var/run/renderd/renderd.stats
 
 [mapnik]
-plugins_dir=/usr/local/lib64/mapnik/input
-font_dir=/usr/local/lib64/mapnik/fonts
+plugins_dir=/usr/lib/mapnik/input
+font_dir=/usr/share/fonts/truetype
 font_dir_recurse=1
 
 [default]


### PR DESCRIPTION
These are _more_ more likely to be what a user has, so less likely to have to be changed
