### PR TITLE
Replace malloc+memset by calloc in render_expired.c

### DIFF
--- a/src/render_expired.c
+++ b/src/render_expired.c
@@ -256,13 +256,12 @@ int main(int argc, char **argv)
         // initialize twopow array
         twopow[i] = (i==0) ? 1 : twopow[i-1]*2;
         unsigned long long fourpow=twopow[i]*twopow[i];
-        tile_requested[i] = (unsigned int *) malloc((fourpow / METATILE) + 1);
+        tile_requested[i] = (unsigned int *) calloc((fourpow / METATILE) + 1, 1);
         if (NULL == tile_requested[i])
         {
             fprintf(stderr, "not enough memory available.\n");
             return 1;
         }
-        memset(tile_requested[i], 0, (fourpow / METATILE) + 1);
     }
 
 


### PR DESCRIPTION
This improves startup time of render_expired, when using --max-zoom=20, as a
2GB array is initialized to 0.

On some trial, the following command switches from 1,5 seconds to ~0 seconds, which is quite noticeable when trying to expire 20 styles every minutes. The same gain is visible on an expires.list generated by a 5 minutes diff.

```
  echo "" | time /usr/bin/render_expired --map admin2 --min-zoom=12 --touch-from=12 --max-zoom=20
```
