### PR TITLE
Make sure that renderd is started after postgresql in init script for debian

### DIFF
--- a/debian/renderd.init
+++ b/debian/renderd.init
@@ -3,6 +3,7 @@
 # Provides:          renderd
 # Required-Start:    $remote_fs
 # Required-Stop:     $remote_fs
+# Should-Start:      postgresql
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
 # Short-Description: Mapnik rendering daemon


### PR DESCRIPTION
This is a minor change in init script so that, when postgresql is enabled on the machine where renderd is running, we are launching renderd only after postgresql. Otherwise, renderd won't render any styles which couldn't connect to postgresql durinig the initialization.

Maybe a better fix is to change renderd initialization to retry postgresql connection at a later time, and not only at startup.
