### PR TITLE
Extend autoconf and automake to use an installed libiniparser

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,9 +1,11 @@
 AUTOMAKE_OPTIONS = foreign
-SUBDIRS = iniparser3.0b
+if !SYSTEM_LIBINIPARSER
+    SUBDIRS = iniparser3.0b
+endif
 
 ACLOCAL_AMFLAGS = -I m4
 
-AM_CPPFLAGS = $(FT2_CFLAGS) $(PTHREAD_CFLAGS) $(MAPNIK_INCLUDES) $(BOOST_CPPFLAGS) $(ICU_CPPFLAGS) $(CAIRO_CFLAGS) $(CAIROMM_CFLAGS) 
+AM_CPPFLAGS = $(FT2_CFLAGS) $(PTHREAD_CFLAGS) $(MAPNIK_INCLUDES) $(BOOST_CPPFLAGS) $(ICU_CPPFLAGS) $(CAIRO_CFLAGS) $(CAIROMM_CFLAGS) -DSYSTEM_LIBINIPARSER=@SYSTEM_LIBINIPARSER@
 
 STORE_SOURCES = src/store.c src/store_file.c src/store_file_utils.c src/store_memcached.c src/store_rados.c src/store_ro_http_proxy.c src/store_ro_composite.c src/store_null.c
 STORE_LDFLAGS = $(LIBMEMCACHED_LDFLAGS) $(LIBRADOS_LDFLAGS) $(LIBCURL) $(CAIRO_LIBS)
@@ -13,8 +15,12 @@ noinst_PROGRAMS = gen_tile_test
 man_MANS = docs/renderd.8 docs/render_expired.1 docs/render_list.1 docs/render_old.1 docs/render_speedtest.1
 
 renderddir = $(sysconfdir)
-renderd_SOURCES = src/daemon.c src/daemon_compat.c src/gen_tile.cpp src/sys_utils.c src/request_queue.c src/cache_expire.c src/metatile.cpp src/parameterize_style.cpp src/protocol_helper.c $(STORE_SOURCES) iniparser3.0b/libiniparser.la
-renderd_LDADD = $(FT2_LIBS) $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(BOOST_LDFLAGS) $(ICU_LDFLAGS) $(STORE_LDFLAGS) -Liniparser3.0b/.libs -liniparser
+renderd_SOURCES = src/daemon.c src/daemon_compat.c src/gen_tile.cpp src/sys_utils.c src/request_queue.c src/cache_expire.c src/metatile.cpp src/parameterize_style.cpp src/protocol_helper.c $(STORE_SOURCES)
+renderd_LDADD = $(FT2_LIBS) $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(BOOST_LDFLAGS) $(ICU_LDFLAGS) $(STORE_LDFLAGS) -liniparser
+if !SYSTEM_LIBINIPARSER
+    renderd_SOURCES += iniparser3.0b/libiniparser.la
+    renderd_LDADD += -Liniparser3.0b/.libs
+endif
 renderd_DATA = renderd.conf
 render_speedtest_SOURCES = src/speedtest.cpp src/protocol_helper.c src/render_submit_queue.c src/sys_utils.c
 render_speedtest_LDADD = $(PTHREAD_CFLAGS)
@@ -25,10 +31,13 @@ render_expired_LDADD = $(PTHREAD_CFLAGS) $(STORE_LDFLAGS)
 render_old_SOURCES = src/store_file_utils.c src/render_old.c src/sys_utils.c src/protocol_helper.c src/render_submit_queue.c
 render_old_LDADD = $(PTHREAD_CFLAGS)
 #convert_meta_SOURCES = src/dir_utils.c src/store.c src/convert_meta.c
-gen_tile_test_SOURCES = src/gen_tile_test.cpp src/metatile.cpp src/request_queue.c src/protocol_helper.c src/daemon.c src/daemon_compat.c src/gen_tile.cpp src/sys_utils.c src/cache_expire.c src/parameterize_style.cpp $(STORE_SOURCES) iniparser3.0b/libiniparser.la 
+gen_tile_test_SOURCES = src/gen_tile_test.cpp src/metatile.cpp src/request_queue.c src/protocol_helper.c src/daemon.c src/daemon_compat.c src/gen_tile.cpp src/sys_utils.c src/cache_expire.c src/parameterize_style.cpp $(STORE_SOURCES)
 gen_tile_test_CFLAGS = -DMAIN_ALREADY_DEFINED $(PTHREAD_CFLAGS)
-gen_tile_test_LDADD = $(FT2_LIBS) $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(BOOST_LDFLAGS) $(ICU_LDFLAGS) $(STORE_LDFLAGS) -Liniparser3.0b/.libs -liniparser
-
+gen_tile_test_LDADD = $(FT2_LIBS) $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(BOOST_LDFLAGS) $(ICU_LDFLAGS) $(STORE_LDFLAGS) -liniparser
+if !SYSTEM_LIBINIPARSER
+    gen_tile_test_SOURCES += iniparser3.0b/libiniparser.la
+    gen_tile_test_LDADD += -Liniparser3.0b/.libs
+endif
 CLEANFILES=*.slo mod_tile.la stderr.out src/*.slo src/*.lo src/.libs/* src/*.la
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -83,5 +83,15 @@ if test "$APXS" = "reject"; then
   AC_MSG_ERROR([Could not find apxs on the path.])
 fi
 
-AC_CONFIG_FILES(Makefile iniparser3.0b/Makefile)
+AC_SEARCH_LIBS([iniparser_load], [iniparser], [have_system_iniparser=yes])
+AM_CONDITIONAL([SYSTEM_LIBINIPARSER], [test "x$have_system_iniparser" = "xyes"])
+if test "x$have_system_iniparser" = "xyes"; then
+    AC_SUBST(SYSTEM_LIBINIPARSER, 1)
+    AC_MSG_NOTICE([Using installed iniparser])
+else
+    AC_SUBST(SYSTEM_LIBINIPARSER, 0)
+    AC_CONFIG_FILES(iniparser3.0b/Makefile)
+    AC_MSG_NOTICE([Building iniparser])
+fi
+AC_CONFIG_FILES(Makefile)
 AC_OUTPUT

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -28,9 +28,13 @@
 
 #define PIDFILE "/var/run/renderd/renderd.pid"
 
+#if SYSTEM_LIBINIPARSER
+#include <iniparser.h>
+#else
 // extern "C" {
 #include "iniparser3.0b/src/iniparser.h"
 // }
+#endif
 
 #ifndef MAIN_ALREADY_DEFINED
 static pthread_t *render_threads;


### PR DESCRIPTION
This helps systems with newer (and therefore relying on libiniparser) samba versions installed.
