### PR TITLE
- fixed hanging debian package installation for mod_tile

### DIFF
--- a/debian/libapache2-mod-tile.postinst
+++ b/debian/libapache2-mod-tile.postinst
@@ -39,6 +39,9 @@ if [ "$1" = configure ] ; then
     true
 fi
 
+#script will hang without this!
+db_stop
+
 #DEBHELPER#
 
 exit 0


### PR DESCRIPTION
Without the final "db_stop" in the postinst script, the installation of the Debian package hangs - at least on Ubuntu 12.04 and 14.04 - and never completes, preventing the package from being installed.
