### PR TITLE
- fixed an autoconf issue that prevented packages compilation on Launchpad

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 AC_PREREQ([2.61])
 AX_CONFIG_NICE
 AC_INIT(mod_tile, 0.1, http://trac.openstreetmap.org)
-AM_INIT_AUTOMAKE(mod_tile,0.1)
+AM_INIT_AUTOMAKE([subdir-objects])
 LT_INIT
 AC_CONFIG_SRCDIR([src/convert_meta.c])
 AC_CONFIG_HEADERS([includes/config.h])


### PR DESCRIPTION
Without this fix, current autoconf versions (e.g. those on Launchpad) will not recursively build sub-projects. Thus, the mod_tile "iniparser" will not be built and mod_tile cannot be linked against it. This prevents Launchpad from building the mod_tile packages, e.g. for PPAs.
