### PR TITLE
SCALE option to produce retina tiles

### DIFF
--- a/includes/daemon.h
+++ b/includes/daemon.h
@@ -37,6 +37,7 @@ typedef struct {
     char tile_dir[PATH_MAX];
     char parameterization[PATH_MAX];
     int tile_px_size;
+    double scale_factor;
     int min_zoom;
     int max_zoom;
     int num_threads;

--- a/renderd.conf
+++ b/renderd.conf
@@ -40,6 +40,7 @@ TILESIZE=256
 ;CORS=http://www.openstreetmap.org
 ;ASPECTX=1
 ;ASPECTY=1
+;SCALE=1.0
 
 ;[style2]
 ;URI=/osm_tiles2/

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -754,6 +754,14 @@ int main(int argc, char **argv)
                 exit(7);
             }
 
+            sprintf(buffer, "%s:scale", name);
+            char *ini_scale = iniparser_getstring(ini, buffer, (char *) "1.0");
+            maps[iconf].scale_factor = atof(ini_scale);
+            if (maps[iconf].scale_factor < 0.1 || maps[iconf].scale_factor > 8.0) {
+                fprintf(stderr, "Scale factor is invalid: %s\n", ini_scale);
+                exit(7);
+            }
+
             sprintf(buffer, "%s:tiledir", name);
             char *ini_tiledir = iniparser_getstring(ini, buffer, (char *) config.tile_dir);
             if (strlen(ini_tiledir) >= (PATH_MAX - 1)) {


### PR DESCRIPTION
Adds a `SCALE` option to `renderd.conf`. This way you can have retina (2x) tiles: just set `TILESIZE=512` + `SCALE=2`. This fork is currently producing tiles [here](http://osmz.ru/vretina.html), exactly with those options.

Also this PR fixes default buffer to be derived from tile size.
