### PR TITLE
Add mapnik's dependencies to MAPNIK_INCLUDES

### DIFF
--- a/m4/ax_lib_mapnik.m4
+++ b/m4/ax_lib_mapnik.m4
@@ -91,6 +91,7 @@ AC_DEFUN([AX_LIB_MAPNIK],
                 if test $? -ne 0; then
                     MAPNIK_INCLUDES=""
                 fi
+                    MAPNIK_INCLUDES="$MAPNIK_INCLUDES `$MAPNIK_CONFIG --dep-includes`"
         	    MAPNIK_LDFLAGS="`$MAPNIK_CONFIG --libs`"
 
         	    MAPNIK_VERSION=`$MAPNIK_CONFIG --version`


### PR DESCRIPTION
Without this we may fail to find the headers for things like agg if they aren't already on the include path.
