### PR TITLE
Check for presence of iniparser.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,9 @@ if test "$APXS" = "reject"; then
   AC_MSG_ERROR([Could not find apxs on the path.])
 fi
 
-AC_SEARCH_LIBS([iniparser_load], [iniparser], [have_system_iniparser=yes])
+AC_SEARCH_LIBS([iniparser_load], [iniparser], [
+	AC_CHECK_HEADERS([iniparser.h], [have_system_iniparser=yes])
+])
 AM_CONDITIONAL([SYSTEM_LIBINIPARSER], [test "x$have_system_iniparser" = "xyes"])
 if test "x$have_system_iniparser" = "xyes"; then
     AC_SUBST(SYSTEM_LIBINIPARSER, 1)


### PR DESCRIPTION
When building against the libiniparser installed on the system, also
check for the presence of iniparser.h. This is essential for
distributions like debian splitting headers into a "-dev" package.
