### PR TITLE
Fixes for FreeBSD

### DIFF
--- a/includes/catch.hpp
+++ b/includes/catch.hpp
@@ -38,6 +38,10 @@
 #define CATCH_ATTRIBUTE_NORETURN
 #endif
 
+#ifdef __FreeBSD__
+#define CATCH_CONFIG_CPP11_NULLPTR
+#endif
+
 #include <sstream>
 #include <stdexcept>
 #include <algorithm>

--- a/src/gen_tile_test.cpp
+++ b/src/gen_tile_test.cpp
@@ -42,6 +42,12 @@
 #include <sys/types.h>
 #include <sys/syscall.h>
 #include <stdlib.h>
+
+#ifdef __FreeBSD__
+#include <pthread.h>
+#include <sys/wait.h>
+#endif
+
 #ifdef __MACH__
 #include <mach/clock.h>
 #include <mach/mach.h>
@@ -62,6 +68,8 @@
 #define NO_QUEUE_REQUESTS 9
 #define NO_TEST_REPEATS 100
 #define NO_THREADS 100
+
+
 
 extern struct projectionconfig * get_projection(const char * srs);
 extern mapnik::box2d<double> tile2prjbounds(struct projectionconfig * prj, int x, int y, int z);
@@ -98,7 +106,11 @@ void *addition_thread(void * arg) {
     struct request_queue * queue = (struct request_queue *)arg;
     struct item * item;
     struct timespec time;
+    #ifdef __FreeBSD__
+    unsigned int seed = (unsigned long long int)pthread_self();
+    #else
     unsigned int seed = syscall(SYS_gettid);
+    #endif
     #ifdef __MACH__ // OS X does not have clock_gettime, use clock_get_time
     clock_serv_t cclock;
     mach_timespec_t mts;

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -65,6 +65,10 @@ APLOG_USE_MODULE(tile);
 #define APACHE24 1
 #endif
 
+#if defined(__FreeBSD__) && !defined(s6_addr32)
+#define s6_addr32 __u6_addr.__u6_addr32
+#endif
+
 apr_shm_t *stats_shm;
 apr_shm_t *delaypool_shm;
 char *shmfilename;


### PR DESCRIPTION
It was impossible to compile mod_tile on FreeBSD (see issue #114 for details about the different problems).
I used `#ifdef __FreeBSD__` blocks, so the changes will only affect FreeBSD users.
Everything remains exactly the same for other operating systems. So it won't break anything.

You have to compile using

```
make CPPFLAGS="-I/usr/local/include"
```

because I didn't know how to add preprocessor flags specifically for FreeBSD using autoconf.
(and I wanted to be sure everything remains exactly the same for users of other operating systems).
If you know how to do that, that would be great to add it to the Makefile.am of configure.ac or whatever file you're supposed to put that in.

I've been using mod_tile like this for a few days now and it works great.
