### PR TITLE
Addition of Amazon S3 tile store module

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -48,10 +48,10 @@ test: gen_tile_test
 	./gen_tile_test
 
 all-local:
-	$(APXS) -c $(DEF_LDLIBS) $(AM_CFLAGS) -I@srcdir@/includes $(AM_LDFLAGS) $(STORE_LDFLAGS) @srcdir@/src/mod_tile.c  @srcdir@/src/sys_utils.c @srcdir@/src/store.c @srcdir@/src/store_file.c @srcdir@/src/store_file_utils.c @srcdir@/src/store_memcached.c @srcdir@/src/store_rados.c @srcdir@/src/store_ro_http_proxy.c @srcdir@/src/store_ro_composite.c @srcdir@/src/store_null.c
+	$(APXS) -c $(DEF_LDLIBS) $(AM_CFLAGS) -I@srcdir@/includes $(AM_LDFLAGS) $(STORE_LDFLAGS) @srcdir@/src/mod_tile.c  @srcdir@/src/sys_utils.c @srcdir@/src/store.c @srcdir@/src/store_file.c @srcdir@/src/store_file_utils.c @srcdir@/src/store_memcached.c @srcdir@/src/store_rados.c @srcdir@/src/store_ro_http_proxy.c @srcdir@/src/store_ro_composite.c @srcdir@/src/store_s3.c @srcdir@/src/store_null.c
 
 install-mod_tile: 
 	mkdir -p $(DESTDIR)`$(APXS) -q LIBEXECDIR`
-	$(APXS) -S LIBEXECDIR=$(DESTDIR)`$(APXS) -q LIBEXECDIR` -c -i $(DEF_LDLIBS) $(AM_CFLAGS) -I@srcdir@/includes $(AM_LDFLAGS) $(STORE_LDFLAGS) @srcdir@/src/mod_tile.c @srcdir@/src/sys_utils.c @srcdir@/src/store.c @srcdir@/src/store_file.c @srcdir@/src/store_file_utils.c @srcdir@/src/store_memcached.c @srcdir@/src/store_rados.c @srcdir@/src/store_ro_http_proxy.c @srcdir@/src/store_ro_composite.c @srcdir@/src/store_null.c
+	$(APXS) -S LIBEXECDIR=$(DESTDIR)`$(APXS) -q LIBEXECDIR` -c -i $(DEF_LDLIBS) $(AM_CFLAGS) -I@srcdir@/includes $(AM_LDFLAGS) $(STORE_LDFLAGS) @srcdir@/src/mod_tile.c @srcdir@/src/sys_utils.c @srcdir@/src/store.c @srcdir@/src/store_file.c @srcdir@/src/store_file_utils.c @srcdir@/src/store_memcached.c @srcdir@/src/store_rados.c @srcdir@/src/store_ro_http_proxy.c @srcdir@/src/store_ro_composite.c @srcdir@/src/store_s3.c @srcdir@/src/store_null.c
 
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,8 @@ ACLOCAL_AMFLAGS = -I m4
 
 AM_CPPFLAGS = $(PTHREAD_CFLAGS) -DSYSTEM_LIBINIPARSER=@SYSTEM_LIBINIPARSER@
 
-STORE_SOURCES = src/store.c src/store_file.c src/store_file_utils.c src/store_memcached.c src/store_rados.c src/store_ro_http_proxy.c src/store_ro_composite.c src/store_null.c
-STORE_LDFLAGS = $(LIBMEMCACHED_LDFLAGS) $(LIBRADOS_LDFLAGS) $(LIBCURL)
+STORE_SOURCES = src/store.c src/store_file.c src/store_file_utils.c src/store_memcached.c src/store_rados.c src/store_ro_http_proxy.c src/store_ro_composite.c src/store_null.c src/store_s3.c
+STORE_LDFLAGS = $(LIBMEMCACHED_LDFLAGS) $(LIBRADOS_LDFLAGS) $(LIBCURL) $(LIBS3_LDFLAGS)
 STORE_CPPFLAGS =
 
 bin_PROGRAMS = renderd render_expired render_list render_speedtest render_old

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ render_old_LDADD = $(PTHREAD_CFLAGS)
 #convert_meta_SOURCES = src/dir_utils.c src/store.c src/convert_meta.c
 gen_tile_test_SOURCES = src/gen_tile_test.cpp src/metatile.cpp src/request_queue.c src/protocol_helper.c src/daemon.c src/daemon_compat.c src/gen_tile.cpp src/sys_utils.c src/cache_expire.c src/parameterize_style.cpp $(STORE_SOURCES)
 gen_tile_test_CFLAGS = -DMAIN_ALREADY_DEFINED $(PTHREAD_CFLAGS) $(STORE_CFLAGS)
-gen_tile_test_CXXFLAGS = $(MAPNIK_CFLAGS)
+gen_tile_test_CXXFLAGS = $(MAPNIK_CFLAGS) $(STORE_CFLAGS)
 gen_tile_test_LDADD = $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(STORE_LDFLAGS) -liniparser
 if !SYSTEM_LIBINIPARSER
     gen_tile_test_SOURCES += iniparser3.0b/libiniparser.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,10 +6,11 @@ endif
 ACLOCAL_AMFLAGS = -I m4
 
 AM_CPPFLAGS = $(PTHREAD_CFLAGS) -DSYSTEM_LIBINIPARSER=@SYSTEM_LIBINIPARSER@
+AM_CFLAGS = $(STORE_CFLAGS)
 
 STORE_SOURCES = src/store.c src/store_file.c src/store_file_utils.c src/store_memcached.c src/store_rados.c src/store_ro_http_proxy.c src/store_ro_composite.c src/store_null.c src/store_s3.c
 STORE_LDFLAGS = $(LIBMEMCACHED_LDFLAGS) $(LIBRADOS_LDFLAGS) $(LIBCURL) $(LIBS3_LDFLAGS)
-STORE_CPPFLAGS =
+STORE_CFLAGS = $(LIBS3_CFLAGS)
 
 bin_PROGRAMS = renderd render_expired render_list render_speedtest render_old
 noinst_PROGRAMS = gen_tile_test
@@ -34,7 +35,7 @@ render_old_SOURCES = src/store_file_utils.c src/render_old.c src/sys_utils.c src
 render_old_LDADD = $(PTHREAD_CFLAGS)
 #convert_meta_SOURCES = src/dir_utils.c src/store.c src/convert_meta.c
 gen_tile_test_SOURCES = src/gen_tile_test.cpp src/metatile.cpp src/request_queue.c src/protocol_helper.c src/daemon.c src/daemon_compat.c src/gen_tile.cpp src/sys_utils.c src/cache_expire.c src/parameterize_style.cpp $(STORE_SOURCES)
-gen_tile_test_CFLAGS = -DMAIN_ALREADY_DEFINED $(PTHREAD_CFLAGS)
+gen_tile_test_CFLAGS = -DMAIN_ALREADY_DEFINED $(PTHREAD_CFLAGS) $(STORE_CFLAGS)
 gen_tile_test_CXXFLAGS = $(MAPNIK_CFLAGS)
 gen_tile_test_LDADD = $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(STORE_LDFLAGS) -liniparser
 if !SYSTEM_LIBINIPARSER

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,11 @@ AC_CHECK_LIB(rados, rados_version, [
     LIBRADOS_LDFLAGS='-lrados'
     AC_SUBST(LIBRADOS_LDFLAGS)
 ][])
+AC_CHECK_LIB(s3, S3_deinitialize, [
+    AC_DEFINE([HAVE_LIBS3], [1], [Have found libs3])
+    LIBS3_LDFLAGS='-ls3'
+    AC_SUBST(LIBS3_LDFLAGS)
+][])
 
 AC_CHECK_FUNCS([bzero gethostbyname gettimeofday inet_ntoa memset mkdir pow select socket strchr strdup strerror strrchr strstr strtol strtoul utime],[],[AC_MSG_ERROR([One of the required functions was not found])])
 AC_CHECK_FUNCS([daemon getloadavg],[],[])

--- a/configure.ac
+++ b/configure.ac
@@ -53,11 +53,46 @@ AC_CHECK_LIB(rados, rados_version, [
     LIBRADOS_LDFLAGS='-lrados'
     AC_SUBST(LIBRADOS_LDFLAGS)
 ][])
-AC_CHECK_LIB(s3, S3_deinitialize, [
-    AC_DEFINE([HAVE_LIBS3], [1], [Have found libs3])
-    LIBS3_LDFLAGS='-ls3'
-    AC_SUBST(LIBS3_LDFLAGS)
-][])
+
+AC_ARG_WITH([libs3],
+    [AS_HELP_STRING([--with-libs3[=DIR]],[path to libs3])],
+    [
+    libs3_dir="$withval"
+    if test "$libs3_dir" != "no"; then
+      if test "$libs3_dir" != "yes"; then
+        AC_MSG_CHECKING([for libs3])
+        if test -f "$libs3_dir/include/libs3.h"; then
+          AC_DEFINE([HAVE_LIBS3], [1], [Have found libs3])
+          LIBS3_LDFLAGS='-ls3'
+          AC_SUBST(LIBS3_LDFLAGS)
+          LIBS3_CFLAGS="-I$libs3_dir/include"
+          AC_SUBST(LIBS3_CFLAGS)
+          AC_MSG_RESULT($libs3_dir)
+        else
+          AC_MSG_ERROR([no libs3 found at $libs3_dir])
+        fi
+      else
+	AC_CHECK_LIB(s3, S3_deinitialize,
+        [
+            AC_DEFINE([HAVE_LIBS3], [1], [Have found libs3])
+	    LIBS3_LDFLAGS='-ls3'
+            AC_SUBST(LIBS3_LDFLAGS)
+        ],
+        [
+            AC_MSG_ERROR([no libs3 found])
+        ])
+      fi
+    fi
+    ],
+    [
+	AC_CHECK_LIB(s3, S3_deinitialize,
+        [
+            AC_DEFINE([HAVE_LIBS3], [1], [Have found libs3])
+	    LIBS3_LDFLAGS='-ls3'
+            AC_SUBST(LIBS3_LDFLAGS)
+        ],
+        [])
+    ])
 
 AC_CHECK_FUNCS([bzero gethostbyname gettimeofday inet_ntoa memset mkdir pow select socket strchr strdup strerror strrchr strstr strtol strtoul utime],[],[AC_MSG_ERROR([One of the required functions was not found])])
 AC_CHECK_FUNCS([daemon getloadavg],[],[])

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,7 @@ AC_ARG_WITH([libs3],
         AC_MSG_CHECKING([for libs3])
         if test -f "$libs3_dir/include/libs3.h"; then
           AC_DEFINE([HAVE_LIBS3], [1], [Have found libs3])
-          LIBS3_LDFLAGS='-ls3'
+          LIBS3_LDFLAGS="-L$libs3_dir/lib -ls3"
           AC_SUBST(LIBS3_LDFLAGS)
           LIBS3_CFLAGS="-I$libs3_dir/include"
           AC_SUBST(LIBS3_CFLAGS)

--- a/includes/metatile.h
+++ b/includes/metatile.h
@@ -12,21 +12,22 @@ extern "C" {
 
 #define META_MAGIC "META"
 #define META_MAGIC_COMPRESSED "METZ"
-    
-    struct entry {
-        int offset;
-        int size;
-    };
 
-    struct meta_layout {
-        char magic[4];
-        int count; // METATILE ^ 2
-        int x, y, z; // lowest x,y of this metatile, plus z
-        struct entry index[]; // count entries
-        // Followed by the tile data
-        // The index offsets are measured from the start of the file
-    };
+struct entry {
+    int offset;
+    int size;
+};
 
+struct meta_layout {
+    char magic[4];
+    int count; // METATILE ^ 2
+    int x, y, z; // lowest x,y of this metatile, plus z
+    struct entry index[]; // count entries
+    // Followed by the tile data
+    // The index offsets are measured from the start of the file
+};
+
+#define METATILE_HEADER_LEN (sizeof(struct meta_layout) + METATILE * METATILE * sizeof(struct entry))
 
 #ifdef __cplusplus
 }

--- a/includes/store_file.h
+++ b/includes/store_file.h
@@ -6,9 +6,8 @@ extern "C" {
 #endif
 
 #include "store.h"
-    
-    struct storage_backend * init_storage_file(const char * tile_dir);
-    int xyzo_to_meta(char *path, size_t len, const char *tile_dir, const char *xmlconfig, const char *options, int x, int y, int z);
+
+struct storage_backend * init_storage_file(const char * tile_dir);
 
 #ifdef __cplusplus
 }

--- a/includes/store_file_utils.h
+++ b/includes/store_file_utils.h
@@ -27,6 +27,7 @@ int path_to_xyz(const char *tilepath, const char *path, char *xmlconfig, int *px
 /* New meta-tile storage functions */
 /* Returns the path to the meta-tile and the offset within the meta-tile */
 int xyz_to_meta(char *path, size_t len, const char *tile_dir, const char *xmlconfig, int x, int y, int z);
+int xyzo_to_meta(char *path, size_t len, const char *tile_dir, const char *xmlconfig, const char *options, int x, int y, int z);
 #endif
 
 #ifdef __cplusplus

--- a/includes/store_s3.h
+++ b/includes/store_s3.h
@@ -1,0 +1,16 @@
+#ifndef STORES3_H
+#define STORES3_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "store.h"
+
+struct storage_backend* init_storage_s3(const char *connection_string);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/mod_tile.conf
+++ b/mod_tile.conf
@@ -14,6 +14,7 @@ LoadModule tile_module modules/mod_tile.so
 # The file based storage uses a simple file path as its storage path ( /path/to/tiledir )
 # The RADOS based storage takes a location to the rados config file and a pool name ( rados://poolname/path/to/ceph.conf )
 # The memcached based storage currently has no configuration options and always connects to memcached on localhost ( memcached:// )
+# The S3 based storage takes an access key, bucket, and path ( s3://access_key_id:secret_access_key[@host]/bucket_name[/basepath] )
 #
 # The storage path can be overwritten on a style by style basis from the style TileConfigFile
     ModTileTileDir /var/lib/mod_tile

--- a/readme.txt
+++ b/readme.txt
@@ -46,8 +46,8 @@ daemon to render (or re-render) the tile.
 resources on the server and how out of date they are.
 
 4) Use tile storage other than a plain posix file system.
-e.g it can store tiles in a ceph object store, or proxy them
-from another tile server.
+e.g it can store tiles in a ceph object store, an Amazon S3 bucket,
+or proxy them from another tile server.
 
 5) Tile expiry. It estimates when the tile is next
 likely to be rendered and adds the appropriate HTTP

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -932,7 +932,7 @@ int main(int argc, char **argv)
     if (foreground) {
         fprintf(stderr, "Running in foreground mode...\n");
     } else {
-        if (daemon(1, 0) != 0) {
+        if (daemon(1, 1) != 0) {
             fprintf(stderr, "can't daemonize: %s\n", strerror(errno));
         }
         /* write pid file */

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -932,7 +932,7 @@ int main(int argc, char **argv)
     if (foreground) {
         fprintf(stderr, "Running in foreground mode...\n");
     } else {
-        if (daemon(0, 0) != 0) {
+        if (daemon(1, 0) != 0) {
             fprintf(stderr, "can't daemonize: %s\n", strerror(errno));
         }
         /* write pid file */

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -430,8 +430,8 @@ int server_socket_init(renderd_config *sConfig) {
         addrI.sin6_addr = in6addr_any;
         addrI.sin6_port = htons(sConfig->ipport);
         if (bind(fd, (struct sockaddr *) &addrI, sizeof(addrI)) < 0) {
-            fprintf(stderr, "socket bind failed for: %s:%i\n",
-                    sConfig->iphostname, sConfig->ipport);
+            fprintf(stderr, "socket bind failed for: %s:%i: %s\n",
+                    sConfig->iphostname, sConfig->ipport, strerror(errno));
             close(fd);
             exit(3);
         }
@@ -453,7 +453,8 @@ int server_socket_init(renderd_config *sConfig) {
 
         old = umask(0); // Need daemon socket to be writeable by apache
         if (bind(fd, (struct sockaddr *) &addrU, sizeof(addrU)) < 0) {
-            fprintf(stderr, "socket bind failed for: %s\n", sConfig->socketname);
+            fprintf(stderr, "socket bind failed for: %s: %s\n",
+                    sConfig->socketname, strerror(errno));
             close(fd);
             exit(3);
         }

--- a/src/gen_tile_test.cpp
+++ b/src/gen_tile_test.cpp
@@ -1238,6 +1238,10 @@ TEST_CASE("storage-backend/s3", "S3 tile storage backend") {
     ctx.secretAccessKey = accesskey;
     ctx.bucketName = bucketname;
     ctx.hostName = NULL;
+    ctx.protocol = S3ProtocolHTTPS;
+    ctx.uriStyle = S3UriStyleVirtualHost;
+    ctx.securityToken = NULL;
+
     S3ResponseHandler handler;
     handler.completeCallback = &test_s3_complete_callback;
     handler.propertiesCallback = &test_s3_properties_callback;

--- a/src/gen_tile_test.cpp
+++ b/src/gen_tile_test.cpp
@@ -973,7 +973,7 @@ TEST_CASE("storage-backend/s3", "S3 tile storage backend") {
     const char *bucketpath = "mod_tile_test";
 
     s3_connection_url = (char*) malloc(1024);
-    sprintf(s3_connection_url, "s3://%s:%s/%s/%s", keyid, accesskey, bucketname, bucketpath);
+    snprintf(s3_connection_url, 1024, "s3://%s:%s/%s/%s", keyid, accesskey, bucketname, bucketpath);
 
     SECTION("storage-backend/s3/initialise", "should return 1") {
         struct storage_backend *store = NULL;

--- a/src/metatile.cpp
+++ b/src/metatile.cpp
@@ -32,7 +32,6 @@
 #include "cache_expire.h"
 #include "request_queue.h"
 
-
 metaTile::metaTile(const std::string &xmlconfig, const std::string &options, int x, int y, int z):
     x_(x), y_(y), z_(z), xmlconfig_(xmlconfig), options_(options) {
     clear();

--- a/src/store.c
+++ b/src/store.c
@@ -21,6 +21,7 @@
 #include "store_rados.h"
 #include "store_ro_http_proxy.h"
 #include "store_ro_composite.h"
+#include "store_s3.h"
 #include "store_null.h"
 
 //TODO: Make this function handle different logging backends, depending on if on compiles it from apache or something else
@@ -101,6 +102,11 @@ struct storage_backend * init_storage_backend(const char * options) {
     if (strstr(options,"composite:{") == options) {
         log_message(STORE_LOGLVL_DEBUG, "init_storage_backend: initialising ro_composite storage backend at: %s", options);
         store = init_storage_ro_composite(options);
+        return store;
+    }
+    if (strstr(options, "s3://") == options) {
+        log_message(STORE_LOGLVL_DEBUG, "init_storage_backend: initialising s3 storage backend at: %s", options);
+        store = init_storage_s3(options);
         return store;
     }
     if (strstr(options,"null://") == options) {

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -49,8 +49,7 @@ static int file_tile_read(struct storage_backend * store, const char *xmlconfig,
     char path[PATH_MAX];
     int meta_offset, fd;
     unsigned int pos;
-    unsigned int header_len = sizeof(struct meta_layout) + METATILE*METATILE*sizeof(struct entry);
-    struct meta_layout *m = (struct meta_layout *)malloc(header_len);
+    struct meta_layout *m = (struct meta_layout *)malloc(METATILE_HEADER_LEN);
     size_t file_offset, tile_size;
 
     meta_offset = xyzo_to_meta(path, sizeof(path), store->storage_ctx, xmlconfig, options, x, y, z);
@@ -63,8 +62,8 @@ static int file_tile_read(struct storage_backend * store, const char *xmlconfig,
     }
 
     pos = 0;
-    while (pos < header_len) {
-        size_t len = header_len - pos;
+    while (pos < METATILE_HEADER_LEN) {
+        size_t len = METATILE_HEADER_LEN - pos;
         int got = read(fd, ((unsigned char *) m) + pos, len);
         if (got < 0) {
             snprintf(log_msg,PATH_MAX - 1, "Failed to read complete header for metatile %s Reason: %s\n", path, strerror(errno));
@@ -77,7 +76,7 @@ static int file_tile_read(struct storage_backend * store, const char *xmlconfig,
             break;
         }
     }
-    if (pos < header_len) {
+    if (pos < METATILE_HEADER_LEN) {
         snprintf(log_msg,PATH_MAX - 1, "Meta file %s too small to contain header\n", path);
         close(fd);
         free(m);

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -271,6 +271,9 @@ static int store_s3_metatile_write(struct storage_backend *store, const char *xm
     request.tile = (char*) buf;
     request.tile_size = sz;
     request.cur_offset = 0;
+    request.tile_expired = 0;
+    request.result = S3StatusOK;
+    request.error_details = NULL;
 
     S3PutProperties props;
     props.contentType = "application/octet-stream";

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -264,7 +265,7 @@ static int store_s3_tile_write(struct storage_backend *store, const char *xmlcon
 
     struct s3_tile_request request;
     request.path = path;
-    request.tile = buf;
+    request.tile = (char*) buf;
     request.tile_size = sz;
     request.cur_offset = 0;
 
@@ -350,7 +351,6 @@ static int store_s3_close_storage(struct storage_backend *store)
 {
     struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
 
-    free(ctx->basepath);
     if (ctx->cache.tile)
         free(ctx->cache.tile);
     S3_deinitialize();

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -7,8 +7,6 @@
 #include <sys/types.h>
 #include <pthread.h>
 
-#define HAVE_LIBS3 1
-
 #ifdef HAVE_LIBS3
 #include <libs3.h>
 #endif
@@ -22,6 +20,19 @@
 
 static pthread_mutex_t qLock;
 static int store_s3_initialized = 0;
+
+struct s3_tile_request
+{
+    const char *path;
+    size_t tile_size;
+    int stat_only;
+    char *tile;
+    int64_t tile_mod_time;
+    int tile_expired;
+    size_t cur_offset;
+    S3Status result;
+    const S3ErrorDetails *error_details;
+};
 
 struct tile_cache
 {
@@ -38,58 +49,127 @@ struct store_s3_ctx
     struct tile_cache cache;
 };
 
-struct MemoryStruct
-{
-    char *memory;
-    size_t size;
-};
-
 static char* store_s3_xyz_to_storagekey(struct storage_backend *store, int x, int y, int z, char *key)
 {
-    snprintf(key, PATH_MAX - 1, "/%s/%i/%i/%i.png", ((struct store_s3_ctx *) (store->storage_ctx))->basepath, z, x, y);
+    snprintf(key, PATH_MAX - 1, "/%s/%i/%i/%i.png", ((struct store_s3_ctx*) (store->storage_ctx))->basepath, z, x, y);
     return key;
 }
 
-static int store_s3_tile_retrieve(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z)
+static S3Status store_s3_properties_callback(const S3ResponseProperties *properties, void *callbackData)
 {
-    struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
-    char * path;
+    struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_properties_callback: got properties for tile, length: %ld, content type: %s", properties->contentLength, properties->contentType);
+
+    rqst->tile_size = properties->contentLength;
+    rqst->tile_mod_time = properties->lastModified;
+    if (!rqst->stat_only) {
+        rqst->tile = malloc(properties->contentLength);
+        rqst->cur_offset = 0;
+    }
+    rqst->tile_expired = 0;
+    const S3NameValue *respMetadata = properties->metaData;
+    for (int i = 0; i < properties->metaDataCount; i++) {
+        if (0 == strcmp(respMetadata[i].name, "expired")) {
+            rqst->tile_expired = atoi(respMetadata[i].value);
+        }
+    }
+
+    return S3StatusOK;
+}
+
+S3Status store_s3_object_data_callback(int bufferSize, const char *buffer, void *callbackData)
+{
+    struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_object_data_callback: appending %ld bytes to buffer, new offset %ld", bufferSize, rqst->cur_offset
+            + bufferSize);
+    memcpy(rqst->tile + rqst->cur_offset, buffer, bufferSize);
+    rqst->cur_offset += bufferSize;
+    return S3StatusOK;
+}
+
+int store_s3_put_object_data_callback(int bufferSize, char *buffer, void *callbackData)
+{
+    struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
+    size_t bytesToWrite = MAX(bufferSize, rqst->tile_size - rqst->cur_offset);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_properties_callback: got properties for tile, writing %ld bytes to buffer, new offset %ld", bytesToWrite, rqst->cur_offset
+            + bytesToWrite);
+    memcpy(buffer, rqst->tile + rqst->cur_offset, bytesToWrite);
+    rqst->cur_offset += bytesToWrite;
+    int written = 0;
+    if (rqst->cur_offset == rqst->tile_size) {
+        // indicate "end of data"
+        written = 0;
+    } else {
+        written = bytesToWrite;
+    }
+    return written;
+}
+
+void store_s3_complete_callback(S3Status status, const S3ErrorDetails *errorDetails, void *callbackData)
+{
+    struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_complete_callback: request complete, status %d", status);
+    if (errorDetails) {
+        log_message(STORE_LOGLVL_DEBUG, " error details: %s", errorDetails);
+    }
+    rqst->result = status;
+    rqst->error_details = errorDetails;
+}
+
+static int store_s3_tile_retrieve(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z)
+{
+    struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
+    char *path = NULL;
 
     if ((ctx->cache.x == x) && (ctx->cache.y == y) && (ctx->cache.z == z)
             && (strcmp(ctx->cache.xmlname, xmlconfig) == 0)) {
-        log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_fetch: Got a cached tile");
+        log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Got a cached tile");
         return 1;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_fetch: Fetching tile");
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Fetching tile");
 
     path = malloc(PATH_MAX);
 
     store_s3_xyz_to_storagekey(store, x, y, z, path);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_fetch: retrieving file %s", path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: retrieving object %s", path);
 
-    S3Status res = S3_get_object(ctx->ctx, path, NULL, 0, 0, NULL, handler, NULL);
+    struct S3GetObjectHandler getObjectHandler;
+    getObjectHandler.responseHandler.propertiesCallback =
+            &store_s3_properties_callback;
+    getObjectHandler.responseHandler.completeCallback =
+            &store_s3_complete_callback;
+    getObjectHandler.getObjectDataCallback = &store_s3_object_data_callback;
+
+    struct s3_tile_request request;
+    request.path = path;
+    request.stat_only = 0;
+
+    S3_get_object(ctx->ctx, path, NULL, 0, 0, NULL, &getObjectHandler, &request);
     free(path);
 
-    if (res != S3StatusOK) {
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_fetch: failed to retrieve file: %s", S3_get_status_name(res));
+    if (request.result != S3StatusOK) {
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_retrieve: failed to retrieve object: %d/%s", request.result, request.error_details);
+        if (ctx->cache.tile) {
+            free(ctx->cache.tile);
+            ctx->cache.tile = NULL;
+        }
         ctx->cache.x = -1;
         ctx->cache.y = -1;
         ctx->cache.z = -1;
         return -1;
     }
 
-    if (ctx->cache.tile != NULL)
-        free(ctx->cache.tile);
-    ctx->cache.tile = chunk.memory;
-    ctx->cache.st_stat.size = chunk.size;
-    ctx->cache.st_stat.expired = 0;
-    res =
-            curl_easy_getinfo(ctx->ctx, CURLINFO_FILETIME, &(ctx->cache.st_stat.mtime));
-    ctx->cache.st_stat.atime = 0;
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: Read file of size %i", chunk.size);
-    break;
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Read object of size %i", request.tile_size);
 
+    if (ctx->cache.tile) {
+        free(ctx->cache.tile);
+    }
+    ctx->cache.tile = request.tile;
+    ctx->cache.st_stat.size = request.tile_size;
+    ctx->cache.st_stat.atime = 0;
+    ctx->cache.st_stat.mtime = request.tile_mod_time;
+    ctx->cache.st_stat.expired = 0;
     ctx->cache.x = x;
     ctx->cache.y = y;
     ctx->cache.z = z;
@@ -97,31 +177,54 @@ static int store_s3_tile_retrieve(struct storage_backend * store, const char *xm
     return 1;
 }
 
-static int store_s3_tile_read(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg)
+static int store_s3_tile_read(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg)
 {
-    struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
+    struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
 
-    if (store_s3_tile_retrieve(store, xmlconfig, options, x, y, z) > 0) {
-        if (ctx->cache.st_stat.size > sz) {
-            log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: size was too big, overrun %i %i", sz, ctx->cache.st_stat.size);
-            return -1;
-        }
-        memcpy(buf, ctx->cache.tile, ctx->cache.st_stat.size);
-        return ctx->cache.st_stat.size;
-    } else {
+    if (store_s3_tile_retrieve(store, xmlconfig, options, x, y, z) <= 0) {
         log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: Fetching didn't work");
         return -1;
     }
+    if (ctx->cache.st_stat.size > sz) {
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: buffer not big enough for tile (%i < %i)", sz, ctx->cache.st_stat.size);
+        return -1;
+    }
+    memcpy(buf, ctx->cache.tile, ctx->cache.st_stat.size);
+    return ctx->cache.st_stat.size;
 }
 
-static struct stat_info store_s3_tile_stat(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z)
+static struct stat_info store_s3_tile_stat(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z)
 {
-    struct stat_info tile_stat;
-    struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
+    struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
+    char *path = NULL;
 
-    if (store_s3_tile_retrieve(store, xmlconfig, options, x, y, z) > 0) {
+    if ((ctx->cache.x == x) && (ctx->cache.y == y) && (ctx->cache.z == z)
+            && (strcmp(ctx->cache.xmlname, xmlconfig) == 0)) {
+        log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: Got a cached tile");
         return ctx->cache.st_stat;
-    } else {
+    }
+
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: Fetching tile properties");
+
+    path = malloc(PATH_MAX);
+
+    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: getting properties for object %s", path);
+
+    struct S3ResponseHandler responseHandler;
+    responseHandler.propertiesCallback = &store_s3_properties_callback;
+    responseHandler.completeCallback = &store_s3_complete_callback;
+
+    struct s3_tile_request request;
+    request.path = path;
+    request.stat_only = 1;
+
+    S3_head_object(ctx->ctx, path, NULL, &responseHandler, &request);
+    free(path);
+
+    struct stat_info tile_stat;
+    if (request.result != S3StatusOK) {
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_retrieve: failed to retrieve object properties: %d/%s", request.result, request.error_details);
         tile_stat.size = -1;
         tile_stat.expired = 0;
         tile_stat.mtime = 0;
@@ -129,38 +232,125 @@ static struct stat_info store_s3_tile_stat(struct storage_backend * store, const
         tile_stat.ctime = 0;
         return tile_stat;
     }
+
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Read properties");
+
+    tile_stat.size = request.tile_size;
+    tile_stat.expired = request.tile_expired;
+    tile_stat.mtime = request.tile_mod_time;
+    tile_stat.atime = 0;
+    tile_stat.ctime = 0;
+    return tile_stat;
 }
 
-static char * store_s3_tile_storage_id(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char * string)
+static char* store_s3_tile_storage_id(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char * string)
 {
-
     return store_s3_xyz_to_storagekey(store, x, y, z, string);
 }
 
-static int store_s3_metatile_write(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz)
+static int store_s3_tile_write(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz)
 {
-    log_message(STORE_LOGLVL_ERR, "store_s3_metatile_write: This is a readonly storage backend. Write functionality isn't implemented");
-    return -1;
+    struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
+    char *path = malloc(PATH_MAX);
+    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: storing object %s", path);
+
+    struct S3PutObjectHandler putObjectHandler;
+    putObjectHandler.responseHandler.propertiesCallback =
+            &store_s3_properties_callback;
+    putObjectHandler.responseHandler.completeCallback =
+            &store_s3_complete_callback;
+    putObjectHandler.putObjectDataCallback = &store_s3_put_object_data_callback;
+
+    struct s3_tile_request request;
+    request.path = path;
+    request.tile = buf;
+    request.tile_size = sz;
+    request.cur_offset = 0;
+
+    S3_put_object(ctx->ctx, path, sz, NULL, NULL, &putObjectHandler, &request);
+    free(path);
+
+    if (request.result != S3StatusOK) {
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_write: failed to write object: %d/%s", request.result, request.error_details);
+        return -1;
+    }
+
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: Wrote object of size %i", request.tile_size);
+
+    return sz;
 }
 
-static int store_s3_metatile_delete(struct storage_backend * store, const char *xmlconfig, int x, int y, int z)
+static int store_s3_tile_delete(struct storage_backend *store, const char *xmlconfig, int x, int y, int z)
 {
-    log_message(STORE_LOGLVL_ERR, "store_s3_metatile_expire: This is a readonly storage backend. Write functionality isn't implemented");
-    return -1;
+    struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
+    char *path = malloc(PATH_MAX);
+    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: deleting object %s", path);
+
+    struct S3ResponseHandler responseHandler;
+    responseHandler.propertiesCallback = &store_s3_properties_callback;
+    responseHandler.completeCallback = &store_s3_complete_callback;
+
+    struct s3_tile_request request;
+    request.path = path;
+    request.stat_only = 1;
+
+    S3_delete_object(ctx->ctx, path, NULL, &responseHandler, &request);
+
+    if (request.result != S3StatusOK) {
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_delete: failed to delete object: %d/%s", request.result, request.error_details);
+        return -1;
+    }
+
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_delete: deleted object");
+
+    return 0;
 }
 
-static int store_s3_metatile_expire(struct storage_backend *store, const char *xmlconfig, int x, int y, int z)
+static int store_s3_tile_expire(struct storage_backend *store, const char *xmlconfig, int x, int y, int z)
 {
+    struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
+    char *path = malloc(PATH_MAX);
+    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_expire: expiring object %s", path);
 
-    log_message(STORE_LOGLVL_ERR, "store_s3_metatile_expire: This is a readonly storage backend. Write functionality isn't implemented");
-    return -1;
+    struct S3ResponseHandler responseHandler;
+    responseHandler.propertiesCallback = &store_s3_properties_callback;
+    responseHandler.completeCallback = &store_s3_complete_callback;
+
+    struct s3_tile_request request;
+    request.path = path;
+    request.cur_offset = 0;
+
+    struct S3NameValue expireTag;
+    expireTag.name = "expired";
+    expireTag.value = "1";
+
+    struct S3PutProperties putProperties;
+    putProperties.metaDataCount = 1;
+    putProperties.metaData = &expireTag;
+
+    int64_t lastModified;
+
+    S3_copy_object(ctx->ctx, path, ctx->ctx->bucketName, path, &putProperties, &lastModified, 0, NULL, NULL, &responseHandler, &request);
+    free(path);
+
+    if (request.result != S3StatusOK) {
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_expire: failed to update object: %d/%s", request.result, request.error_details);
+        return -1;
+    }
+
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_expire: Updated object metadata");
+
+    return 0;
 }
 
 static int store_s3_close_storage(struct storage_backend *store)
 {
     struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
 
-    free(ctx->baseurl);
+    free(ctx->basepath);
     if (ctx->cache.tile)
         free(ctx->cache.tile);
     S3_deinitialize();
@@ -170,7 +360,7 @@ static int store_s3_close_storage(struct storage_backend *store)
     return 0;
 }
 
-#endif //Have curl
+#endif //Have libs3
 
 struct storage_backend * init_storage_s3(const char *connection_string)
 {
@@ -232,9 +422,9 @@ struct storage_backend * init_storage_s3(const char *connection_string)
 
     store->tile_read = &store_s3_tile_read;
     store->tile_stat = &store_s3_tile_stat;
-    store->metatile_write = &store_s3_metatile_write;
-    store->metatile_delete = &store_s3_metatile_delete;
-    store->metatile_expire = &store_s3_metatile_expire;
+    store->metatile_write = &store_s3_tile_write;
+    store->metatile_delete = &store_s3_tile_delete;
+    store->metatile_expire = &store_s3_tile_expire;
     store->tile_storage_id = &store_s3_tile_storage_id;
     store->close_storage = &store_s3_close_storage;
 

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -1,0 +1,243 @@
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <limits.h>
+#include <string.h>
+#include <sys/types.h>
+#include <pthread.h>
+
+#define HAVE_LIBS3 1
+
+#ifdef HAVE_LIBS3
+#include <libs3.h>
+#endif
+
+#include "store.h"
+#include "store_s3.h"
+#include "render_config.h"
+#include "protocol.h"
+
+#ifdef HAVE_LIBS3
+
+static pthread_mutex_t qLock;
+static int store_s3_initialized = 0;
+
+struct tile_cache
+{
+    struct stat_info st_stat;
+    char *tile;
+    int x, y, z;
+    char xmlname[XMLCONFIG_MAX];
+};
+
+struct store_s3_ctx
+{
+    S3BucketContext* ctx;
+    const char *basepath;
+    struct tile_cache cache;
+};
+
+struct MemoryStruct
+{
+    char *memory;
+    size_t size;
+};
+
+static char* store_s3_xyz_to_storagekey(struct storage_backend *store, int x, int y, int z, char *key)
+{
+    snprintf(key, PATH_MAX - 1, "/%s/%i/%i/%i.png", ((struct store_s3_ctx *) (store->storage_ctx))->basepath, z, x, y);
+    return key;
+}
+
+static int store_s3_tile_retrieve(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z)
+{
+    struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
+    char * path;
+
+    if ((ctx->cache.x == x) && (ctx->cache.y == y) && (ctx->cache.z == z)
+            && (strcmp(ctx->cache.xmlname, xmlconfig) == 0)) {
+        log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_fetch: Got a cached tile");
+        return 1;
+    }
+
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_fetch: Fetching tile");
+
+    path = malloc(PATH_MAX);
+
+    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_fetch: retrieving file %s", path);
+
+    S3Status res = S3_get_object(ctx->ctx, path, NULL, 0, 0, NULL, handler, NULL);
+    free(path);
+
+    if (res != S3StatusOK) {
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_fetch: failed to retrieve file: %s", S3_get_status_name(res));
+        ctx->cache.x = -1;
+        ctx->cache.y = -1;
+        ctx->cache.z = -1;
+        return -1;
+    }
+
+    if (ctx->cache.tile != NULL)
+        free(ctx->cache.tile);
+    ctx->cache.tile = chunk.memory;
+    ctx->cache.st_stat.size = chunk.size;
+    ctx->cache.st_stat.expired = 0;
+    res =
+            curl_easy_getinfo(ctx->ctx, CURLINFO_FILETIME, &(ctx->cache.st_stat.mtime));
+    ctx->cache.st_stat.atime = 0;
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: Read file of size %i", chunk.size);
+    break;
+
+    ctx->cache.x = x;
+    ctx->cache.y = y;
+    ctx->cache.z = z;
+    strcpy(ctx->cache.xmlname, xmlconfig);
+    return 1;
+}
+
+static int store_s3_tile_read(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg)
+{
+    struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
+
+    if (store_s3_tile_retrieve(store, xmlconfig, options, x, y, z) > 0) {
+        if (ctx->cache.st_stat.size > sz) {
+            log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: size was too big, overrun %i %i", sz, ctx->cache.st_stat.size);
+            return -1;
+        }
+        memcpy(buf, ctx->cache.tile, ctx->cache.st_stat.size);
+        return ctx->cache.st_stat.size;
+    } else {
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: Fetching didn't work");
+        return -1;
+    }
+}
+
+static struct stat_info store_s3_tile_stat(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z)
+{
+    struct stat_info tile_stat;
+    struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
+
+    if (store_s3_tile_retrieve(store, xmlconfig, options, x, y, z) > 0) {
+        return ctx->cache.st_stat;
+    } else {
+        tile_stat.size = -1;
+        tile_stat.expired = 0;
+        tile_stat.mtime = 0;
+        tile_stat.atime = 0;
+        tile_stat.ctime = 0;
+        return tile_stat;
+    }
+}
+
+static char * store_s3_tile_storage_id(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char * string)
+{
+
+    return store_s3_xyz_to_storagekey(store, x, y, z, string);
+}
+
+static int store_s3_metatile_write(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz)
+{
+    log_message(STORE_LOGLVL_ERR, "store_s3_metatile_write: This is a readonly storage backend. Write functionality isn't implemented");
+    return -1;
+}
+
+static int store_s3_metatile_delete(struct storage_backend * store, const char *xmlconfig, int x, int y, int z)
+{
+    log_message(STORE_LOGLVL_ERR, "store_s3_metatile_expire: This is a readonly storage backend. Write functionality isn't implemented");
+    return -1;
+}
+
+static int store_s3_metatile_expire(struct storage_backend *store, const char *xmlconfig, int x, int y, int z)
+{
+
+    log_message(STORE_LOGLVL_ERR, "store_s3_metatile_expire: This is a readonly storage backend. Write functionality isn't implemented");
+    return -1;
+}
+
+static int store_s3_close_storage(struct storage_backend *store)
+{
+    struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
+
+    free(ctx->baseurl);
+    if (ctx->cache.tile)
+        free(ctx->cache.tile);
+    S3_deinitialize();
+    free(ctx);
+    free(store);
+
+    return 0;
+}
+
+#endif //Have curl
+
+struct storage_backend * init_storage_s3(const char *connection_string)
+{
+#ifndef HAVE_LIBS3
+    log_message(STORE_LOGLVL_ERR,
+            "init_storage_s3: Support for libs3 and therefore S3 storage has not been compiled into this program");
+    return NULL;
+#else
+    struct storage_backend *store = malloc(sizeof(struct storage_backend));
+    struct store_s3_ctx *ctx = malloc(sizeof(struct store_s3_ctx));
+
+    S3Status res;
+
+    log_message(STORE_LOGLVL_DEBUG, "init_storage_s3: initializing S3 storage backend for %s", connection_string);
+
+    if (!store || !ctx) {
+        log_message(STORE_LOGLVL_ERR, "init_storage_s3: failed to allocate memory for context");
+        if (store)
+            free(store);
+        if (ctx)
+            free(ctx);
+        return NULL;
+    }
+
+    ctx->cache.x = -1;
+    ctx->cache.y = -1;
+    ctx->cache.z = -1;
+    ctx->cache.tile = NULL;
+    ctx->cache.xmlname[0] = 0;
+
+    pthread_mutex_lock(&qLock);
+    if (!store_s3_initialized) {
+        log_message(STORE_LOGLVL_DEBUG, "init_storage_s3: Global init of curl", connection_string);
+        res = S3_initialize(NULL, S3_INIT_ALL, NULL);
+        store_s3_initialized = 1;
+    } else {
+        res = S3StatusOK;
+    }
+    pthread_mutex_unlock(&qLock);
+    if (res != S3StatusOK) {
+        log_message(STORE_LOGLVL_ERR, "init_storage_s3: failed to initialize S3 library: %s", S3_get_status_name(res));
+        free(ctx);
+        free(store);
+        return NULL;
+    }
+
+    // parse out the context information from the URL: s3://<key id>:<secret key>@<hostname>/<bucket>[/<basepath>]
+    ctx->ctx = malloc(sizeof(struct S3BucketContext));
+
+    char *fullurl = strdup(connection_string);
+    fullurl = &fullurl[5]; // advance past "s3://"
+    ctx->ctx->accessKeyId = strsep(&fullurl, ":");
+    ctx->ctx->secretAccessKey = strsep(&fullurl, "@");
+    ctx->ctx->hostName = strsep(&fullurl, "/");
+    ctx->ctx->bucketName = strsep(&fullurl, "/");
+    ctx->basepath = fullurl;
+
+    store->storage_ctx = ctx;
+
+    store->tile_read = &store_s3_tile_read;
+    store->tile_stat = &store_s3_tile_stat;
+    store->metatile_write = &store_s3_metatile_write;
+    store->metatile_delete = &store_s3_metatile_delete;
+    store->metatile_expire = &store_s3_metatile_expire;
+    store->tile_storage_id = &store_s3_tile_storage_id;
+    store->close_storage = &store_s3_close_storage;
+
+    return store;
+#endif
+}

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -117,10 +117,10 @@ static int store_s3_tile_read(struct storage_backend *store, const char *xmlconf
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = malloc(PATH_MAX);
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: fetching tile");
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: fetching tile");
 
     int tile_offset = store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, path, PATH_MAX);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: retrieving object %s", path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: retrieving object %s", path);
 
     struct S3GetObjectHandler getObjectHandler;
     getObjectHandler.responseHandler.propertiesCallback = &store_s3_properties_callback;
@@ -143,11 +143,11 @@ static int store_s3_tile_read(struct storage_backend *store, const char *xmlconf
         if (request.error_details && request.error_details->message) {
             msg = request.error_details->message;
         }
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_retrieve: failed to retrieve object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: failed to retrieve object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
         return -1;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Read object of size %i", request.tile_size);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: Read object of size %i", request.tile_size);
 
     // extract tile from metatile
 
@@ -259,7 +259,7 @@ static int store_s3_metatile_write(struct storage_backend *store, const char *xm
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = malloc(PATH_MAX);
     store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, path, PATH_MAX);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: storing object %s, size %ld", path, sz);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_metatile_write: storing object %s, size %ld", path, sz);
 
     struct S3PutObjectHandler putObjectHandler;
     putObjectHandler.responseHandler.propertiesCallback = &store_s3_properties_callback;
@@ -301,11 +301,11 @@ static int store_s3_metatile_write(struct storage_backend *store, const char *xm
                 msg2 = request.error_details->furtherDetails;
             }
         }
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_write: failed to write object: %d(%s)/%s%s", request.result, S3_get_status_name(request.result), msg, msg2);
+        log_message(STORE_LOGLVL_ERR, "store_s3_metatile_write: failed to write object: %d(%s)/%s%s", request.result, S3_get_status_name(request.result), msg, msg2);
         return -1;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: Wrote object of size %i", sz);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_metatile_write: Wrote object of size %i", sz);
 
     return sz;
 }
@@ -315,7 +315,7 @@ static int store_s3_metatile_delete(struct storage_backend *store, const char *x
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = malloc(PATH_MAX);
     store_s3_xyz_to_storagekey(store, xmlconfig, NULL, x, y, z, path, PATH_MAX);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: deleting object %s", path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_metatile_delete: deleting object %s", path);
 
     struct S3ResponseHandler responseHandler;
     responseHandler.propertiesCallback = &store_s3_properties_callback;
@@ -339,11 +339,11 @@ static int store_s3_metatile_delete(struct storage_backend *store, const char *x
         if (request.error_details && request.error_details->message) {
             msg = request.error_details->message;
         }
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_delete: failed to delete object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
+        log_message(STORE_LOGLVL_ERR, "store_s3_metatile_delete: failed to delete object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
         return -1;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_delete: deleted object");
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_metatile_delete: deleted object");
 
     return 0;
 }
@@ -353,7 +353,7 @@ static int store_s3_metatile_expire(struct storage_backend *store, const char *x
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = malloc(PATH_MAX);
     store_s3_xyz_to_storagekey(store, xmlconfig, NULL, x, y, z, path, PATH_MAX);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_expire: expiring object %s", path);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_metatile_expire: expiring object %s", path);
 
     struct S3ResponseHandler responseHandler;
     responseHandler.propertiesCallback = &store_s3_properties_callback;
@@ -394,11 +394,11 @@ static int store_s3_metatile_expire(struct storage_backend *store, const char *x
         if (request.error_details && request.error_details->message) {
             msg = request.error_details->message;
         }
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_expire: failed to update object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
+        log_message(STORE_LOGLVL_ERR, "store_s3_metatile_expire: failed to update object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
         return -1;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_expire: Updated object metadata");
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_metatile_expire: Updated object metadata");
 
     return 0;
 }

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -94,7 +94,7 @@ int store_s3_put_object_data_callback(int bufferSize, char *buffer, void *callba
         log_message(STORE_LOGLVL_DEBUG, "store_s3_put_object_data_callback: completed put");
         return 0;
     }
-    size_t bytesToWrite = MAX(bufferSize, rqst->tile_size - rqst->cur_offset);
+    size_t bytesToWrite = MIN(bufferSize, rqst->tile_size - rqst->cur_offset);
     log_message(STORE_LOGLVL_DEBUG, "store_s3_put_object_data_callback: uploading data, writing %ld bytes to buffer, cur offset %ld, new offset %ld", bytesToWrite, rqst->cur_offset, rqst->cur_offset + bytesToWrite);
     memcpy(buffer, rqst->tile + rqst->cur_offset, bytesToWrite);
     rqst->cur_offset += bytesToWrite;

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -13,7 +13,9 @@
 #endif
 
 #include "store.h"
+#include "store_file_utils.h"
 #include "store_s3.h"
+#include "metatile.h"
 #include "render_config.h"
 #include "protocol.h"
 
@@ -22,11 +24,9 @@
 static pthread_mutex_t qLock;
 static int store_s3_initialized = 0;
 
-struct s3_tile_request
-{
+struct s3_tile_request {
     const char *path;
     size_t tile_size;
-    int stat_only;
     char *tile;
     int64_t tile_mod_time;
     int tile_expired;
@@ -35,38 +35,29 @@ struct s3_tile_request
     const S3ErrorDetails *error_details;
 };
 
-struct tile_cache
-{
-    struct stat_info st_stat;
-    char *tile;
-    int x, y, z;
-    char xmlname[XMLCONFIG_MAX];
-};
-
-struct store_s3_ctx
-{
+struct store_s3_ctx {
     S3BucketContext* ctx;
     const char *basepath;
-    struct tile_cache cache;
 };
 
-static char* store_s3_xyz_to_storagekey(struct storage_backend *store, int x, int y, int z, char *key)
+static int store_s3_xyz_to_storagekey(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char *key, size_t keylen)
 {
-    snprintf(key, PATH_MAX - 1, "/%s/%i/%i/%i.png", ((struct store_s3_ctx*) (store->storage_ctx))->basepath, z, x, y);
-    return key;
+    int offset;
+    if (options) {
+        offset = xyzo_to_meta(key, keylen, ((struct store_s3_ctx*) (store->storage_ctx))->basepath, xmlconfig, options, x, y, z);
+    } else {
+        offset = xyz_to_meta(key, keylen, ((struct store_s3_ctx*) (store->storage_ctx))->basepath, xmlconfig, x, y, z);
+    }
+
+    return offset;
 }
 
 static S3Status store_s3_properties_callback(const S3ResponseProperties *properties, void *callbackData)
 {
     struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_properties_callback: got properties for tile, length: %ld, content type: %s", properties->contentLength, properties->contentType);
 
     rqst->tile_size = properties->contentLength;
     rqst->tile_mod_time = properties->lastModified;
-    if (!rqst->stat_only) {
-        rqst->tile = malloc(properties->contentLength);
-        rqst->cur_offset = 0;
-    }
     rqst->tile_expired = 0;
     const S3NameValue *respMetadata = properties->metaData;
     for (int i = 0; i < properties->metaDataCount; i++) {
@@ -75,14 +66,21 @@ static S3Status store_s3_properties_callback(const S3ResponseProperties *propert
         }
     }
 
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_properties_callback: got properties for tile %s, length: %ld, content type: %s, expired: %d", rqst->path, rqst->tile_size, properties->contentType, rqst->tile_expired);
+
     return S3StatusOK;
 }
 
 S3Status store_s3_object_data_callback(int bufferSize, const char *buffer, void *callbackData)
 {
     struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_object_data_callback: appending %ld bytes to buffer, new offset %ld", bufferSize, rqst->cur_offset
-            + bufferSize);
+
+    if (rqst->cur_offset == 0 && rqst->tile == NULL) {
+        log_message(STORE_LOGLVL_DEBUG, "store_s3_object_data_callback: allocating %ld byte buffer for tile", rqst->tile_size);
+        rqst->tile = malloc(rqst->tile_size);
+    }
+
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_object_data_callback: appending %ld bytes to buffer, new offset %ld", bufferSize, rqst->cur_offset + bufferSize);
     memcpy(rqst->tile + rqst->cur_offset, buffer, bufferSize);
     rqst->cur_offset += bufferSize;
     return S3StatusOK;
@@ -91,112 +89,108 @@ S3Status store_s3_object_data_callback(int bufferSize, const char *buffer, void 
 int store_s3_put_object_data_callback(int bufferSize, char *buffer, void *callbackData)
 {
     struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
-    size_t bytesToWrite = MAX(bufferSize, rqst->tile_size - rqst->cur_offset);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_properties_callback: got properties for tile, writing %ld bytes to buffer, new offset %ld", bytesToWrite, rqst->cur_offset
-            + bytesToWrite);
-    memcpy(buffer, rqst->tile + rqst->cur_offset, bytesToWrite);
-    rqst->cur_offset += bytesToWrite;
-    int written = 0;
     if (rqst->cur_offset == rqst->tile_size) {
         // indicate "end of data"
-        written = 0;
-    } else {
-        written = bytesToWrite;
+        log_message(STORE_LOGLVL_DEBUG, "store_s3_put_object_data_callback: completed put");
+        return 0;
     }
-    return written;
+    size_t bytesToWrite = MAX(bufferSize, rqst->tile_size - rqst->cur_offset);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_put_object_data_callback: uploading data, writing %ld bytes to buffer, cur offset %ld, new offset %ld", bytesToWrite, rqst->cur_offset, rqst->cur_offset + bytesToWrite);
+    memcpy(buffer, rqst->tile + rqst->cur_offset, bytesToWrite);
+    rqst->cur_offset += bytesToWrite;
+    return bytesToWrite;
 }
 
 void store_s3_complete_callback(S3Status status, const S3ErrorDetails *errorDetails, void *callbackData)
 {
     struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
     log_message(STORE_LOGLVL_DEBUG, "store_s3_complete_callback: request complete, status %d (%s)", status, S3_get_status_name(status));
-    if (errorDetails && errorDetails->message
-            && (strlen(errorDetails->message) > 0)) {
-        log_message(STORE_LOGLVL_DEBUG, "  error details: %s", errorDetails);
+    if (errorDetails && errorDetails->message && (strlen(errorDetails->message) > 0)) {
+        log_message(STORE_LOGLVL_DEBUG, "  error details: %s", errorDetails->message);
     }
     rqst->result = status;
     rqst->error_details = errorDetails;
 }
 
-static int store_s3_tile_retrieve(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z)
+static int store_s3_tile_read(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int *compressed, char *log_msg)
 {
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
-    char *path = NULL;
+    char *path = malloc(PATH_MAX);
 
-    if ((ctx->cache.x == x) && (ctx->cache.y == y) && (ctx->cache.z == z)
-            && (strcmp(ctx->cache.xmlname, xmlconfig) == 0)) {
-        log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Got a cached tile");
-        return 1;
-    }
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: fetching tile");
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Fetching tile");
-
-    path = malloc(PATH_MAX);
-
-    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    int tile_offset = store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, path, PATH_MAX);
     log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: retrieving object %s", path);
 
     struct S3GetObjectHandler getObjectHandler;
-    getObjectHandler.responseHandler.propertiesCallback =
-            &store_s3_properties_callback;
-    getObjectHandler.responseHandler.completeCallback =
-            &store_s3_complete_callback;
+    getObjectHandler.responseHandler.propertiesCallback = &store_s3_properties_callback;
+    getObjectHandler.responseHandler.completeCallback = &store_s3_complete_callback;
     getObjectHandler.getObjectDataCallback = &store_s3_object_data_callback;
 
     struct s3_tile_request request;
     request.path = path;
-    request.stat_only = 0;
+    request.cur_offset = 0;
+    request.tile = NULL;
+    request.tile_expired = 0;
+    request.tile_mod_time = 0;
+    request.tile_size = 0;
 
     S3_get_object(ctx->ctx, path, NULL, 0, 0, NULL, &getObjectHandler, &request);
     free(path);
 
     if (request.result != S3StatusOK) {
-        const char *msg = "<unknown error>";
+        const char *msg = "";
         if (request.error_details && request.error_details->message) {
             msg = request.error_details->message;
         }
         log_message(STORE_LOGLVL_ERR, "store_s3_tile_retrieve: failed to retrieve object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
-        if (ctx->cache.tile) {
-            free(ctx->cache.tile);
-            ctx->cache.tile = NULL;
-        }
-        ctx->cache.x = -1;
-        ctx->cache.y = -1;
-        ctx->cache.z = -1;
         return -1;
     }
 
     log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Read object of size %i", request.tile_size);
 
-    if (ctx->cache.tile) {
-        free(ctx->cache.tile);
-    }
-    ctx->cache.tile = request.tile;
-    ctx->cache.st_stat.size = request.tile_size;
-    ctx->cache.st_stat.atime = 0;
-    ctx->cache.st_stat.mtime = request.tile_mod_time;
-    ctx->cache.st_stat.expired = 0;
-    ctx->cache.x = x;
-    ctx->cache.y = y;
-    ctx->cache.z = z;
-    strcpy(ctx->cache.xmlname, xmlconfig);
-    return 1;
-}
+    // extract tile from metatile
 
-static int store_s3_tile_read(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * log_msg)
-{
-    struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
+    if (request.tile_size < METATILE_HEADER_LEN) {
+        snprintf(log_msg, PATH_MAX - 1, "Meta file %s too small to contain header\n", path);
+        free(request.tile);
+        return -3;
+    }
+    struct meta_layout *m = (struct meta_layout*) request.tile;
 
-    if (store_s3_tile_retrieve(store, xmlconfig, options, x, y, z) <= 0) {
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: retrieval failed");
-        return -1;
+    if (memcmp(m->magic, META_MAGIC, strlen(META_MAGIC))) {
+        if (memcmp(m->magic, META_MAGIC_COMPRESSED, strlen(META_MAGIC_COMPRESSED))) {
+            snprintf(log_msg, PATH_MAX - 1, "Meta file %s header magic mismatch\n", path);
+            free(request.tile);
+            return -4;
+        } else {
+            *compressed = 1;
+        }
+    } else {
+        *compressed = 0;
     }
-    if (ctx->cache.st_stat.size > sz) {
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: buffer not big enough for tile (%i < %i)", sz, ctx->cache.st_stat.size);
-        return -1;
+
+    if (m->count != (METATILE * METATILE)) {
+        snprintf(log_msg, PATH_MAX - 1, "Meta file %s header bad count %d != %d\n", path, m->count, METATILE * METATILE);
+        free(request.tile);
+        return -5;
     }
-    memcpy(buf, ctx->cache.tile, ctx->cache.st_stat.size);
-    return ctx->cache.st_stat.size;
+
+    int buffer_offset = m->index[tile_offset].offset;
+    int tile_size = m->index[tile_offset].size;
+
+    if (tile_size > sz) {
+        snprintf(log_msg, PATH_MAX - 1, "tile of length %d too big to fit buffer of length %zd\n", tile_size, sz);
+        free(request.tile);
+        return -6;
+    }
+
+    memcpy(buf, request.tile + buffer_offset, tile_size);
+
+    free(request.tile);
+    request.tile = NULL;
+
+    return tile_size;
 }
 
 static struct stat_info store_s3_tile_stat(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z)
@@ -204,17 +198,11 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = NULL;
 
-    if ((ctx->cache.x == x) && (ctx->cache.y == y) && (ctx->cache.z == z)
-            && (strcmp(ctx->cache.xmlname, xmlconfig) == 0)) {
-        log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: got a cached tile");
-        return ctx->cache.st_stat;
-    }
-
     log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: Fetching tile properties");
 
     path = malloc(PATH_MAX);
 
-    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, path, PATH_MAX);
     log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: getting properties for object %s", path);
 
     struct S3ResponseHandler responseHandler;
@@ -223,18 +211,24 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
 
     struct s3_tile_request request;
     request.path = path;
-    request.stat_only = 1;
+    request.error_details = NULL;
+    request.cur_offset = 0;
+    request.result = S3StatusOK;
+    request.tile = NULL;
+    request.tile_expired = 0;
+    request.tile_mod_time = 0;
+    request.tile_size = 0;
 
     S3_head_object(ctx->ctx, path, NULL, &responseHandler, &request);
     free(path);
 
     struct stat_info tile_stat;
     if (request.result != S3StatusOK) {
-        const char *msg = "<unknown error>";
+        const char *msg = "";
         if (request.error_details && request.error_details->message) {
             msg = request.error_details->message;
         }
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_retrieve: failed to retrieve object properties: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_stat: failed to retrieve object properties: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
         tile_stat.size = -1;
         tile_stat.expired = 0;
         tile_stat.mtime = 0;
@@ -243,7 +237,7 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
         return tile_stat;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_retrieve: Read properties");
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: Read properties");
 
     tile_stat.size = request.tile_size;
     tile_stat.expired = request.tile_expired;
@@ -253,23 +247,23 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
     return tile_stat;
 }
 
-static char* store_s3_tile_storage_id(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char * string)
+static char* store_s3_tile_storage_id(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char *string)
 {
-    return store_s3_xyz_to_storagekey(store, x, y, z, string);
+    // FIXME: assumes PATH_MAX for length of provided string
+    store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, string, PATH_MAX);
+    return string;
 }
 
-static int store_s3_tile_write(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz)
+static int store_s3_metatile_write(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz)
 {
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = malloc(PATH_MAX);
-    store_s3_xyz_to_storagekey(store, x, y, z, path);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: storing object %s", path);
+    store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, path, PATH_MAX);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: storing object %s, size %ld", path, sz);
 
     struct S3PutObjectHandler putObjectHandler;
-    putObjectHandler.responseHandler.propertiesCallback =
-            &store_s3_properties_callback;
-    putObjectHandler.responseHandler.completeCallback =
-            &store_s3_complete_callback;
+    putObjectHandler.responseHandler.propertiesCallback = &store_s3_properties_callback;
+    putObjectHandler.responseHandler.completeCallback = &store_s3_complete_callback;
     putObjectHandler.putObjectDataCallback = &store_s3_put_object_data_callback;
 
     struct s3_tile_request request;
@@ -278,28 +272,46 @@ static int store_s3_tile_write(struct storage_backend *store, const char *xmlcon
     request.tile_size = sz;
     request.cur_offset = 0;
 
-    S3_put_object(ctx->ctx, path, sz, NULL, NULL, &putObjectHandler, &request);
+    S3PutProperties props;
+    props.contentType = "application/octet-stream";
+    props.cacheControl = NULL;
+    props.cannedAcl = S3CannedAclPrivate; // results in no ACL header in POST
+    props.contentDispositionFilename = NULL;
+    props.contentEncoding = NULL;
+    props.expires = -1;
+    props.md5 = NULL;
+    props.metaData = NULL;
+    props.metaDataCount = 0;
+    props.useServerSideEncryption = 0;
+
+    S3_put_object(ctx->ctx, path, sz, &props, NULL, &putObjectHandler, &request);
     free(path);
 
     if (request.result != S3StatusOK) {
-        const char *msg = "<unknown error>";
-        if (request.error_details && request.error_details->message) {
-            msg = request.error_details->message;
+        const char *msg = "";
+        const char *msg2 = "";
+        if (request.error_details) {
+            if (request.error_details->message) {
+                msg = request.error_details->message;
+            }
+            if (request.error_details->furtherDetails) {
+                msg2 = request.error_details->furtherDetails;
+            }
         }
-        log_message(STORE_LOGLVL_ERR, "store_s3_tile_write: failed to write object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
+        log_message(STORE_LOGLVL_ERR, "store_s3_tile_write: failed to write object: %d(%s)/%s%s", request.result, S3_get_status_name(request.result), msg, msg2);
         return -1;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: Wrote object of size %i", request.tile_size);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: Wrote object of size %i", sz);
 
     return sz;
 }
 
-static int store_s3_tile_delete(struct storage_backend *store, const char *xmlconfig, int x, int y, int z)
+static int store_s3_metatile_delete(struct storage_backend *store, const char *xmlconfig, int x, int y, int z)
 {
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = malloc(PATH_MAX);
-    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    store_s3_xyz_to_storagekey(store, xmlconfig, NULL, x, y, z, path, PATH_MAX);
     log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_write: deleting object %s", path);
 
     struct S3ResponseHandler responseHandler;
@@ -308,12 +320,11 @@ static int store_s3_tile_delete(struct storage_backend *store, const char *xmlco
 
     struct s3_tile_request request;
     request.path = path;
-    request.stat_only = 1;
 
     S3_delete_object(ctx->ctx, path, NULL, &responseHandler, &request);
 
     if (request.result != S3StatusOK) {
-        const char *msg = "<unknown error>";
+        const char *msg = "";
         if (request.error_details && request.error_details->message) {
             msg = request.error_details->message;
         }
@@ -326,11 +337,11 @@ static int store_s3_tile_delete(struct storage_backend *store, const char *xmlco
     return 0;
 }
 
-static int store_s3_tile_expire(struct storage_backend *store, const char *xmlconfig, int x, int y, int z)
+static int store_s3_metatile_expire(struct storage_backend *store, const char *xmlconfig, int x, int y, int z)
 {
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = malloc(PATH_MAX);
-    store_s3_xyz_to_storagekey(store, x, y, z, path);
+    store_s3_xyz_to_storagekey(store, xmlconfig, NULL, x, y, z, path, PATH_MAX);
     log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_expire: expiring object %s", path);
 
     struct S3ResponseHandler responseHandler;
@@ -345,17 +356,24 @@ static int store_s3_tile_expire(struct storage_backend *store, const char *xmlco
     expireTag.name = "expired";
     expireTag.value = "1";
 
-    struct S3PutProperties putProperties;
-    putProperties.metaDataCount = 1;
-    putProperties.metaData = &expireTag;
+    S3PutProperties props;
+    props.contentType = "application/octet-stream";
+    props.cacheControl = NULL;
+    props.cannedAcl = S3CannedAclPrivate; // results in no ACL header in POST
+    props.contentDispositionFilename = NULL;
+    props.contentEncoding = NULL;
+    props.expires = -1;
+    props.md5 = NULL;
+    props.metaDataCount = 1;
+    props.metaData = &expireTag;
 
     int64_t lastModified;
 
-    S3_copy_object(ctx->ctx, path, ctx->ctx->bucketName, path, &putProperties, &lastModified, 0, NULL, NULL, &responseHandler, &request);
+    S3_copy_object(ctx->ctx, path, ctx->ctx->bucketName, path, &props, &lastModified, 0, NULL, NULL, &responseHandler, &request);
     free(path);
 
     if (request.result != S3StatusOK) {
-        const char *msg = "<unknown error>";
+        const char *msg = "";
         if (request.error_details && request.error_details->message) {
             msg = request.error_details->message;
         }
@@ -370,19 +388,21 @@ static int store_s3_tile_expire(struct storage_backend *store, const char *xmlco
 
 static int store_s3_close_storage(struct storage_backend *store)
 {
-    struct store_s3_ctx * ctx = (struct store_s3_ctx *) (store->storage_ctx);
+    struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
 
-    if (ctx->cache.tile)
-        free(ctx->cache.tile);
     S3_deinitialize();
     free(ctx);
     free(store);
+    store_s3_initialized = 0;
 
     return 0;
 }
 
 static char* url_decode(const char *src)
 {
+    if (NULL == src) {
+        return NULL;
+    }
     char *dst = (char*) malloc(strlen(src) + 1);
     dst[0] = '\0';
     while (*src) {
@@ -426,15 +446,9 @@ struct storage_backend* init_storage_s3(const char *connection_string)
         return NULL;
     }
 
-    ctx->cache.x = -1;
-    ctx->cache.y = -1;
-    ctx->cache.z = -1;
-    ctx->cache.tile = NULL;
-    ctx->cache.xmlname[0] = 0;
-
     pthread_mutex_lock(&qLock);
     if (!store_s3_initialized) {
-        log_message(STORE_LOGLVL_DEBUG, "init_storage_s3: Global init of libs3", connection_string);
+        log_message(STORE_LOGLVL_DEBUG, "init_storage_s3: global init of libs3", connection_string);
         res = S3_initialize(NULL, S3_INIT_ALL, NULL);
         store_s3_initialized = 1;
     } else {
@@ -452,18 +466,30 @@ struct storage_backend* init_storage_s3(const char *connection_string)
     ctx->ctx = malloc(sizeof(struct S3BucketContext));
 
     char *fullurl = strdup(connection_string);
+
     // advance past "s3://"
     fullurl = &fullurl[5];
-    ctx->ctx->accessKeyId = url_decode(strsep(&fullurl, ":"));
+    ctx->ctx->accessKeyId = strsep(&fullurl, ":");
     if (strchr(fullurl, '@')) {
-        ctx->ctx->secretAccessKey = url_decode(strsep(&fullurl, "@"));
-        ctx->ctx->hostName = url_decode(strsep(&fullurl, "/"));
+        ctx->ctx->secretAccessKey = strsep(&fullurl, "@");
+        ctx->ctx->hostName = strsep(&fullurl, "/");
     } else {
-        ctx->ctx->secretAccessKey = url_decode(strsep(&fullurl, "/"));
+        ctx->ctx->secretAccessKey = strsep(&fullurl, "/");
+        ctx->ctx->hostName = NULL;
     }
-    ctx->ctx->bucketName = url_decode(strsep(&fullurl, "/"));
+    ctx->ctx->bucketName = strsep(&fullurl, "/");
 
-    ctx->basepath = url_decode(fullurl);
+    ctx->basepath = fullurl;
+
+    ctx->ctx->accessKeyId = url_decode(ctx->ctx->accessKeyId);
+    ctx->ctx->secretAccessKey = url_decode(ctx->ctx->secretAccessKey);
+    ctx->ctx->hostName = url_decode(ctx->ctx->hostName);
+    ctx->ctx->bucketName = url_decode(ctx->ctx->bucketName);
+    ctx->ctx->protocol = S3ProtocolHTTPS;
+    ctx->ctx->securityToken = NULL;
+    ctx->ctx->uriStyle = S3UriStyleVirtualHost;
+
+    ctx->basepath = url_decode(ctx->basepath);
 
     log_message(STORE_LOGLVL_DEBUG, "init_storage_s3 completed keyid: %s, key: %s, bucket: %s, basepath: %s", ctx->ctx->accessKeyId, ctx->ctx->secretAccessKey, ctx->ctx->bucketName, ctx->basepath);
 
@@ -471,9 +497,9 @@ struct storage_backend* init_storage_s3(const char *connection_string)
 
     store->tile_read = &store_s3_tile_read;
     store->tile_stat = &store_s3_tile_stat;
-    store->metatile_write = &store_s3_tile_write;
-    store->metatile_delete = &store_s3_tile_delete;
-    store->metatile_expire = &store_s3_tile_expire;
+    store->metatile_write = &store_s3_metatile_write;
+    store->metatile_delete = &store_s3_metatile_delete;
+    store->metatile_expire = &store_s3_metatile_expire;
     store->tile_storage_id = &store_s3_tile_storage_id;
     store->close_storage = &store_s3_close_storage;
 

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -76,11 +76,11 @@ S3Status store_s3_object_data_callback(int bufferSize, const char *buffer, void 
     struct s3_tile_request *rqst = (struct s3_tile_request*) callbackData;
 
     if (rqst->cur_offset == 0 && rqst->tile == NULL) {
-        log_message(STORE_LOGLVL_DEBUG, "store_s3_object_data_callback: allocating %ld byte buffer for tile", rqst->tile_size);
+        //log_message(STORE_LOGLVL_DEBUG, "store_s3_object_data_callback: allocating %ld byte buffer for tile", rqst->tile_size);
         rqst->tile = malloc(rqst->tile_size);
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_object_data_callback: appending %ld bytes to buffer, new offset %ld", bufferSize, rqst->cur_offset + bufferSize);
+    //log_message(STORE_LOGLVL_DEBUG, "store_s3_object_data_callback: appending %ld bytes to buffer, new offset %ld", bufferSize, rqst->cur_offset + bufferSize);
     memcpy(rqst->tile + rqst->cur_offset, buffer, bufferSize);
     rqst->cur_offset += bufferSize;
     return S3StatusOK;
@@ -95,7 +95,7 @@ int store_s3_put_object_data_callback(int bufferSize, char *buffer, void *callba
         return 0;
     }
     size_t bytesToWrite = MIN(bufferSize, rqst->tile_size - rqst->cur_offset);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_put_object_data_callback: uploading data, writing %ld bytes to buffer, cur offset %ld, new offset %ld", bytesToWrite, rqst->cur_offset, rqst->cur_offset + bytesToWrite);
+    //log_message(STORE_LOGLVL_DEBUG, "store_s3_put_object_data_callback: uploading data, writing %ld bytes to buffer, cur offset %ld, new offset %ld", bytesToWrite, rqst->cur_offset, rqst->cur_offset + bytesToWrite);
     memcpy(buffer, rqst->tile + rqst->cur_offset, bytesToWrite);
     rqst->cur_offset += bytesToWrite;
     return bytesToWrite;

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -481,7 +481,19 @@ struct storage_backend* init_storage_s3(const char *connection_string)
 
     ctx->basepath = fullurl;
 
+    if (strstr(ctx->ctx->accessKeyId, "${") == ctx->ctx->accessKeyId && strrchr(ctx->ctx->accessKeyId, '}') == (ctx->ctx->accessKeyId + strlen(ctx->ctx->accessKeyId) - 1)) {
+        char tmp[strlen(ctx->ctx->accessKeyId) + 1];
+        strcpy(tmp, ctx->ctx->accessKeyId);
+        tmp[strlen(tmp) - 1] = '\0';
+        ctx->ctx->accessKeyId = getenv(tmp + 2);
+    }
     ctx->ctx->accessKeyId = url_decode(ctx->ctx->accessKeyId);
+    if (strstr(ctx->ctx->secretAccessKey, "${") == ctx->ctx->secretAccessKey && strrchr(ctx->ctx->secretAccessKey, '}') == (ctx->ctx->secretAccessKey + strlen(ctx->ctx->secretAccessKey) - 1)) {
+        char tmp[strlen(ctx->ctx->secretAccessKey) + 1];
+        strcpy(tmp, ctx->ctx->secretAccessKey);
+        tmp[strlen(tmp) - 1] = '\0';
+        ctx->ctx->secretAccessKey = getenv(tmp + 2);
+    }
     ctx->ctx->secretAccessKey = url_decode(ctx->ctx->secretAccessKey);
     ctx->ctx->hostName = url_decode(ctx->ctx->hostName);
     ctx->ctx->bucketName = url_decode(ctx->ctx->bucketName);

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -66,7 +66,7 @@ static S3Status store_s3_properties_callback(const S3ResponseProperties *propert
         }
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_properties_callback: got properties for tile %s, length: %ld, content type: %s, expired: %d", rqst->path, rqst->tile_size, properties->contentType, rqst->tile_expired);
+    //log_message(STORE_LOGLVL_DEBUG, "store_s3_properties_callback: got properties for tile %s, length: %ld, content type: %s, expired: %d", rqst->path, rqst->tile_size, properties->contentType, rqst->tile_expired);
 
     return S3StatusOK;
 }
@@ -227,7 +227,7 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
             if (request.error_details && request.error_details->message) {
                 msg = request.error_details->message;
             }
-            log_message(STORE_LOGLVL_ERR, "store_s3_tile_stat: failed to retrieve object properties: %d (%s) %s", request.result, S3_get_status_name(request.result), msg);
+            log_message(STORE_LOGLVL_ERR, "store_s3_tile_stat: failed to retrieve object properties for %s: %d (%s) %s", path, request.result, S3_get_status_name(request.result), msg);
         }
         tile_stat.size = -1;
         tile_stat.expired = 0;
@@ -396,11 +396,11 @@ static int store_s3_metatile_expire(struct storage_backend *store, const char *x
         if (request.error_details && request.error_details->message) {
             msg = request.error_details->message;
         }
-        log_message(STORE_LOGLVL_ERR, "store_s3_metatile_expire: failed to update object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
+        log_message(STORE_LOGLVL_ERR, "store_s3_metatile_expire: failed to update object: %d (%s)/%s", request.result, S3_get_status_name(request.result), msg);
         return -1;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_metatile_expire: Updated object metadata");
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_metatile_expire: updated object metadata");
 
     return 0;
 }

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -453,8 +453,6 @@ struct storage_backend* init_storage_s3(const char *connection_string)
 
     S3Status res;
 
-    log_message(STORE_LOGLVL_DEBUG, "init_storage_s3: initializing S3 storage backend for %s", connection_string);
-
     if (!store || !ctx) {
         log_message(STORE_LOGLVL_ERR, "init_storage_s3: failed to allocate memory for context");
         if (store)

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -120,7 +120,7 @@ static int store_s3_tile_read(struct storage_backend *store, const char *xmlconf
     //log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: fetching tile");
 
     int tile_offset = store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, path, PATH_MAX);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: retrieving object %s", path);
+    //log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: retrieving object %s", path);
 
     struct S3GetObjectHandler getObjectHandler;
     getObjectHandler.responseHandler.propertiesCallback = &store_s3_properties_callback;
@@ -136,7 +136,6 @@ static int store_s3_tile_read(struct storage_backend *store, const char *xmlconf
     request.tile_size = 0;
 
     S3_get_object(ctx->ctx, path, NULL, 0, 0, NULL, &getObjectHandler, &request);
-    free(path);
 
     if (request.result != S3StatusOK) {
         const char *msg = "";
@@ -144,10 +143,15 @@ static int store_s3_tile_read(struct storage_backend *store, const char *xmlconf
             msg = request.error_details->message;
         }
         log_message(STORE_LOGLVL_ERR, "store_s3_tile_read: failed to retrieve object: %d(%s)/%s", request.result, S3_get_status_name(request.result), msg);
+        free(path);
+        path = NULL;
         return -1;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: Read object of size %i", request.tile_size);
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: retrieved metatile %s of size %i", path, request.tile_size);
+
+    free(path);
+    path = NULL;
 
     // extract tile from metatile
 
@@ -238,7 +242,7 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
         return tile_stat;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: successfully read properties of %s", path);
+    //log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: successfully read properties of %s", path);
 
     tile_stat.size = request.tile_size;
     tile_stat.expired = request.tile_expired;

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -117,7 +117,7 @@ static int store_s3_tile_read(struct storage_backend *store, const char *xmlconf
     struct store_s3_ctx *ctx = (struct store_s3_ctx*) store->storage_ctx;
     char *path = malloc(PATH_MAX);
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: fetching tile");
+    //log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: fetching tile");
 
     int tile_offset = store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, path, PATH_MAX);
     log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_read: retrieving object %s", path);
@@ -199,7 +199,7 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
 
     char *path = malloc(PATH_MAX);
     store_s3_xyz_to_storagekey(store, xmlconfig, options, x, y, z, path, PATH_MAX);
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: getting properties for object %s", path);
+    //log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: getting properties for object %s", path);
 
     struct S3ResponseHandler responseHandler;
     responseHandler.propertiesCallback = &store_s3_properties_callback;
@@ -216,13 +216,12 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
     request.tile_size = 0;
 
     S3_head_object(ctx->ctx, path, NULL, &responseHandler, &request);
-    free(path);
 
     struct stat_info tile_stat;
     if (request.result != S3StatusOK) {
         if (request.result == S3StatusHttpErrorNotFound) {
             // tile does not exist
-            log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: tile not found in storage");
+            //log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: tile not found in storage");
         } else {
             const char *msg = "";
             if (request.error_details && request.error_details->message) {
@@ -235,16 +234,18 @@ static struct stat_info store_s3_tile_stat(struct storage_backend *store, const 
         tile_stat.mtime = 0;
         tile_stat.atime = 0;
         tile_stat.ctime = 0;
+        free(path);
         return tile_stat;
     }
 
-    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: successfully read properties");
+    log_message(STORE_LOGLVL_DEBUG, "store_s3_tile_stat: successfully read properties of %s", path);
 
     tile_stat.size = request.tile_size;
     tile_stat.expired = request.tile_expired;
     tile_stat.mtime = request.tile_mod_time;
     tile_stat.atime = 0;
     tile_stat.ctime = 0;
+    free(path);
     return tile_stat;
 }
 

--- a/src/store_s3.c
+++ b/src/store_s3.c
@@ -410,7 +410,7 @@ static int store_s3_close_storage(struct storage_backend *store)
 
     S3_deinitialize();
     free(ctx);
-    free(store);
+    store->storage_ctx = NULL;
     store_s3_initialized = 0;
 
     return 0;


### PR DESCRIPTION
I added support to mod_tile for using an Amazon S3 bucket for metatile storage, using the libs3 library to implement the S3 API communication. This allows a cluster of EC2 tile servers to share a tile store. The changes include:
- new store_s3 module with all storage methods implemented. configuration of S3 storage is done using a connection string formatted as follows:
  
   `s3://<S3 access key ID>:<S3 secret key>[@<S3 host>]/<bucket name>[/<base path>]`
- autoconf support for detecting presence of the libs3 library
- S3 unit tests in the gen_tile_test program

If autoconf detects the libs3 library, the S3-related tests will be included in gen_tile_test. These tests require environment variables to be set containing the S3 access credentials: `S3_ACCESS_KEY_ID`, `S3_SECRET_ACCESS_KEY`, and `S3_BUCKET_NAME`. If libs3 support is compiled in, and these environment variables are not defined, gen_tile_test will have failed assertions on that section of the test. I'm certainly open to other options for behavior, but this was simplest.

As a possibly optional change, I changed the parameters to the `daemon()` call to allow the working directory and stdout/stderr handles of `renderd` to be specified in the systemd unit specification (which is launching `renderd` in our setup). This is certainly not directly required for libs3 support, but should cause no change in behavior in the vast majority of instances. I'm more than willing to drop this change from the PR if you're concerned about the impacts.
