### PR TITLE
Also load TTC font files

### DIFF
--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -169,7 +169,7 @@ static void load_fonts(const char *font_dir, int recurse)
             continue;
         }
         p = strrchr(path, '.');
-        if (p && (!strcmp(p, ".ttf") || !strcmp(p, ".otf"))) {
+        if (p && (!strcmp(p, ".ttf") || !strcmp(p, ".otf") || !strcmp(p, ".ttc"))) {
             syslog(LOG_DEBUG, "DEBUG: Loading font: %s", path);
             freetype_engine::register_font(path);
         }


### PR DESCRIPTION
Fixes #141 .
As discussed in https://github.com/gravitystorm/openstreetmap-carto/issues/2391 and https://github.com/gravitystorm/openstreetmap-carto/issues/2397 , the Noto CJK fonts that the openstreetmap-carto style uses are currently not used on the rendering servers. They have the extension ".ttc" and are supported by Mapnik.
I have not tested this pull request, but I assume it will solve the problem.