### PR TITLE
Issue #132 Fixed compilation for Mapnik 3.0.12

### DIFF
--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -193,7 +193,7 @@ static void parameterize_map_max_connections(Map &m, int num_threads) {
         parameters params = l.datasource()->params();
         if (params.find("max_size") == params.end()) {
             sprintf(tmp, "%i", num_threads + 2);
-            params["max_size"] = tmp;
+            params["max_size"] = std::string(tmp);
         }
 #if MAPNIK_VERSION >= 200200
         l.set_datasource(datasource_cache::instance().create(params));


### PR DESCRIPTION
Looks like mapnik 3.0.12 is using mapnik::util::variant which is incompatible with char*. Quick and simple fix is to wrap it in std::string on assignment.

Havent tested this with older versions of mapnik but it should be good?
