### PR TITLE
Update render queue limits

### DIFF
--- a/includes/render_config.h
+++ b/includes/render_config.h
@@ -76,12 +76,10 @@
 #define QUEUE_MAX (64)
 #define REQ_LIMIT (32)
 #define DIRTY_LIMIT (216000)
-#define HASHIDX_SIZE (477856)
 #else
 #define QUEUE_MAX (1024)
 #define REQ_LIMIT (512)
-#define DIRTY_LIMIT (10000)
-#define HASHIDX_SIZE (22123)
+#define DIRTY_LIMIT (2160000)
 #endif
 
 // Penalty for client making an invalid request (in seconds)

--- a/includes/render_config.h
+++ b/includes/render_config.h
@@ -72,14 +72,15 @@
 
 // Typical osm.org render server can render 7 metatiles per second, and has average load of 4.5 metatiles per second.
 // Queue depth of (7 - 4.5) * 86400 = 216000 moves the load from the busy part of the day to the night time
+#define DIRTY_LIMIT (216000)
+#define HASHIDX_SIZE (477856)
+
 #ifdef METATILE
 #define QUEUE_MAX (64)
 #define REQ_LIMIT (32)
-#define DIRTY_LIMIT (216000)
 #else
 #define QUEUE_MAX (1024)
 #define REQ_LIMIT (512)
-#define DIRTY_LIMIT (2160000)
 #endif
 
 // Penalty for client making an invalid request (in seconds)

--- a/includes/render_config.h
+++ b/includes/render_config.h
@@ -70,17 +70,18 @@
 //Legacy - not needed on new installs
 //#undef METATILEFALLBACK
 
-// Metatiles are much larger in size so we don't need big queues to handle large areas
+// Typical osm.org render server can render 7 metatiles per second, and has average load of 4.5 metatiles per second.
+// Queue depth of (7 - 4.5) * 86400 = 216000 moves the load from the busy part of the day to the night time
 #ifdef METATILE
 #define QUEUE_MAX (64)
 #define REQ_LIMIT (32)
-#define DIRTY_LIMIT (1000)
-
+#define DIRTY_LIMIT (216000)
+#define HASHIDX_SIZE (477856)
 #else
 #define QUEUE_MAX (1024)
 #define REQ_LIMIT (512)
 #define DIRTY_LIMIT (10000)
-#define HASHIDX_SIZE 22123
+#define HASHIDX_SIZE (22123)
 #endif
 
 // Penalty for client making an invalid request (in seconds)

--- a/includes/request_queue.h
+++ b/includes/request_queue.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif
 
-#define HASHIDX_SIZE 2213
-
 typedef struct {
     long noDirtyRender;
     long noReqRender;
@@ -79,5 +77,3 @@ void request_queue_copy_stats(struct request_queue * queue, stats_struct * stats
 }
 #endif
 #endif
-
-


### PR DESCRIPTION
Adjust render queue depth so that a rendering server dirty queue length is shifted from several minutes (1000 / 7 ~= 142 s  ~= 2.3 minutes) to a whole day.

Metrics are taken from http://munin.osm.org/static/dynazoom.html?cgiurl_graph=/munin-cgi/munin-cgi-graph&plugin_name=openstreetmap/yevaud.openstreetmap/renderd_processed&size_x=800&size_y=400&start_epoch=1483213021&stop_epoch=1483904221 