### PR TITLE
Wrong comment character in renderd.conf

### DIFF
--- a/renderd.conf
+++ b/renderd.conf
@@ -1,22 +1,22 @@
 [renderd]
-;socketname=/var/run/renderd/renderd.sock
+#socketname=/var/run/renderd/renderd.sock
 num_threads=4
 tile_dir=/var/lib/mod_tile
 stats_file=/var/run/renderd/renderd.stats
 
-;[renderd01]
-;iphostname=::1
-;ipport=7654
-;num_threads=4
-;tile_dir=rados://tiles/etc/ceph/ceph.conf
-;stats_file=/var/run/renderd/renderd.stats
+#[renderd01]
+#iphostname=::1
+#ipport=7654
+#num_threads=4
+#tile_dir=rados://tiles/etc/ceph/ceph.conf
+#stats_file=/var/run/renderd/renderd.stats
 
-;[renderd02]
-;iphostname=::1
-;ipport=7654
-;num_threads=8
-;tile_dir=memcached://
-;stats_file=/var/run/renderd/renderd.stats
+#[renderd02]
+#iphostname=::1
+#ipport=7654
+#num_threads=8
+#tile_dir=memcached://
+#stats_file=/var/run/renderd/renderd.stats
 
 [mapnik]
 plugins_dir=/usr/lib/mapnik/input
@@ -29,32 +29,32 @@ TILEDIR=/var/lib/mod_tile
 XML=/home/jburgess/osm/svn.openstreetmap.org/applications/rendering/mapnik/osm-local.xml
 HOST=tile.openstreetmap.org
 TILESIZE=256
-;HTCPHOST=proxy.openstreetmap.org
-;** config options used by mod_tile, but not renderd **
-;MINZOOM=0
-;MAXZOOM=18
-;TYPE=png image/png
-;DESCRIPTION=This is a description of the tile layer used in the tile json request
-;ATTRIBUTION=&copy;<a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> and <a href=\"http://wiki.openstreetmap.org/wiki/Contributors\">contributors</a>, <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a>
-;SERVER_ALIAS=http://localhost/
-;CORS=http://www.openstreetmap.org
-;ASPECTX=1
-;ASPECTY=1
-;SCALE=1.0
+#HTCPHOST=proxy.openstreetmap.org
+#** config options used by mod_tile, but not renderd **
+#MINZOOM=0
+#MAXZOOM=18
+#TYPE=png image/png
+#DESCRIPTION=This is a description of the tile layer used in the tile json request
+#ATTRIBUTION=&copy;<a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> and <a href=\"http://wiki.openstreetmap.org/wiki/Contributors\">contributors</a>, <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a>
+#SERVER_ALIAS=http://localhost/
+#CORS=http://www.openstreetmap.org
+#ASPECTX=1
+#ASPECTY=1
+#SCALE=1.0
 
-;[style2]
-;URI=/osm_tiles2/
-;TILEDIR=rados://tiles/etc/ceph/ceph.conf
-;TILESIZE=512
-;XML=/home/jburgess/osm/svn.openstreetmap.org/applications/rendering/mapnik/osm-local2.xml
-;HOST=tile.openstreetmap.org
-;HTCPHOST=proxy.openstreetmap.org
-;** config options used by mod_tile, but not renderd **
-;MINZOOM=0
-;MAXZOOM=22
-;TYPE=png image/png
-;DESCRIPTION=This is a description of the tile layer used in the tile json request
-;ATTRIBUTION=&copy;<a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> and <a href=\"http://wiki.openstreetmap.org/wiki/Contributors\">contributors</a>, <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a>
-;SERVER_ALIAS=http://localhost/
-;CORS=*
+#[style2]
+#URI=/osm_tiles2/
+#TILEDIR=rados://tiles/etc/ceph/ceph.conf
+#TILESIZE=512
+#XML=/home/jburgess/osm/svn.openstreetmap.org/applications/rendering/mapnik/osm-local2.xml
+#HOST=tile.openstreetmap.org
+#HTCPHOST=proxy.openstreetmap.org
+#** config options used by mod_tile, but not renderd **
+#MINZOOM=0
+#MAXZOOM=22
+#TYPE=png image/png
+#DESCRIPTION=This is a description of the tile layer used in the tile json request
+#ATTRIBUTION=&copy;<a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> and <a href=\"http://wiki.openstreetmap.org/wiki/Contributors\">contributors</a>, <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a>
+#SERVER_ALIAS=http://localhost/
+#CORS=*
 


### PR DESCRIPTION
According to iniParser documentation at [http://ndevilla.free.fr/iniparser/html/](url) valid comment options are:

> Comments in an ini file are:
> - Lines starting with a hash sign
> - Blank lines (only blanks or tabs)
> - Comments given on value lines after the semicolon (if present)