### PR TITLE
daemon.c typo, openstreetmap-tiles-update-expire https

### DIFF
--- a/openstreetmap-tiles-update-expire
+++ b/openstreetmap-tiles-update-expire
@@ -75,7 +75,9 @@ if [ $# -eq 1 ] ; then
     m_info "Initialising Osmosis replication system to $1"
     mkdir $WORKOSM_DIR
     $OSMOSIS_BIN --read-replication-interval-init workingDirectory=$WORKOSM_DIR 1>&2 2> "$OSMOSISLOG"
-    wget "http://osm.personalwerk.de/replicate-sequences/?"$1"T00:00:00Z" -O $WORKOSM_DIR/state.txt
+    wget "http://replicate-sequences.osm.mazdermind.de/?"$1"T00:00:00Z" -O $WORKOSM_DIR/state.txt
+    mv $WORKOSM_DIR/configuration.txt $WORKOSM_DIR/configuration_orig.txt
+    sed "s!baseUrl=http://planet.openstreetmap.org/replication/minute!baseUrl=https://planet.openstreetmap.org/replication/minute!" $WORKOSM_DIR/configuration_orig.txt > $WORKOSM_DIR/configuration.txt
 else
 # make sure the lockfile is removed when we exit and then claim it
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -687,7 +687,7 @@ int main(int argc, char **argv)
         syslog(LOG_ERR, "Failed to initialise request queue");
         exit(1);
     }
-    syslog(LOG_ERR, "Initiating reqyest_queue");
+    syslog(LOG_ERR, "Initiating request_queue");
 
     xmlconfigitem maps[XMLCONFIGS_MAX];
     bzero(maps, sizeof(xmlconfigitem) * XMLCONFIGS_MAX);


### PR DESCRIPTION
Fixed typo in daemon.c, changed "openstreetmap-tiles-update-expire" to work with new locations (minutely updates are now via https, and personalwerk.de has moved to replicate-sequences.osm.mazdermind.de).

If osmosis gets updated to init the location to an https one then the sed here won't be located, but this change will work whether it has been or not.
