### PR TITLE
Conf typos fixed, merging confs.

### DIFF
--- a/debian/tileserver_site.conf
+++ b/debian/tileserver_site.conf
@@ -33,6 +33,15 @@
 # Alternatively (or in addition) you can load all the tile sets defined in the configuration file into this virtual host
     LoadTileConfigFile /etc/renderd.conf
 
+# Specify if mod_tile should keep tile delivery stats, which can be accessed from the URL /mod_tile
+# The default is On. As keeping stats needs to take a lock, this might have some performance impact,
+# but for nearly all intents and purposes this should be negligable and so it is safe to keep this turned on.
+    ModTileEnableStats On
+
+# Turns on bulk mode. In bulk mode, mod_tile does not request any dirty tiles to be rerendered. Missing tiles
+# are always requested in the lowest priority. The default is Off.
+    ModTileBulkMode Off
+
 # Timeout before giving up for a tile to be rendered
     ModTileRequestTimeout 3
 
@@ -111,20 +120,24 @@ ModTileCacheDurationLowZoom 9 518400
 ModTileCacheLastModifiedFactor 0.20
 
 ## Tile Throttling
-## Tile scrappers can often download large numbers of tiles and overly staining tileserver resources
+## Tile scrapers can often download large numbers of tiles and overly strain tileserver resources
 ## mod_tile therefore offers the ability to automatically throttle requests from ip addresses that have
 ## requested a lot of tiles.
 ## The mechanism uses a token bucket approach to shape traffic. I.e. there is an initial pool of n tiles
 ## per ip that can be requested arbitrarily fast. After that this pool gets filled up at a constant rate
-## The algorithm has to metrics. One based on overall tiles served to an ip address and a second one based on
+## The algorithm has two metrics. One based on overall tiles served to an ip address and a second one based on
 ## the number of requests to renderd / tirex to render a new tile. 
 
 ## Overall enable or disable tile throttling
 ModTileEnableTileThrottling Off
-## When the tileserver is behind a proxy one can use the X-Forwarded-For http header to determin the remote IP for throttling
-## 0: don't use X-Forwarded-For
-## 1: Use the first address in the X-Forwarded chain, which should be the client address. However, this may not be trusted.
-## 2: Use the last address in the X-Forwarded chain. If one uses a reverse proxy, this will be the IP address seen by the reverse proxy and can be trusted.
+# Specify if you want to use the connecting IP for throtteling, or use the X-Forwarded-For header to determin the
+# IP address to be used for tile throttling. This can be useful if you have a reverse proxy / http accellerator
+# in front of your tile server.
+# 0 - don't use X-Forward-For and allways use the IP that apache sees
+# 1 - use the client IP address, i.e. the first entry in the X-Forwarded-For list. This works through a cascade of proxies.
+#     However, as the X-Forwarded-For is written by the client this is open to manipulation and can be used to circumvent the throttling
+# 2 - use the last specified IP in the X-Forwarded-For list. If you know all requests come through a reverse proxy
+#     that adds an X-Forwarded-For header, you can trust this IP to be the IP the reverse proxy saw for the request
 ModTileEnableTileThrottlingXForward 0
 
 ## Parameters (poolsize in tiles and topup rate in tiles per second) for throttling tile serving. 

--- a/mod_tile.conf
+++ b/mod_tile.conf
@@ -30,7 +30,7 @@ LoadModule tile_module modules/mod_tile.so
 
 # Specify if mod_tile should keep tile delivery stats, which can be accessed from the URL /mod_tile
 # The default is On. As keeping stats needs to take a lock, this might have some performance impact,
-# but for nearly all intents and purposes this should be negligable ans so it is safe to keep this turned on.
+# but for nearly all intents and purposes this should be negligable and so it is safe to keep this turned on.
     ModTileEnableStats On
 
 # Turns on bulk mode. In bulk mode, mod_tile does not request any dirty tiles to be rerendered. Missing tiles
@@ -122,7 +122,7 @@ ModTileCacheDurationLowZoom 9 518400
 ModTileCacheLastModifiedFactor 0.20
 
 ## Tile Throttling
-## Tile scrapers can often download large numbers of tiles and overly straining tileserver resources
+## Tile scrapers can often download large numbers of tiles and overly strain tileserver resources
 ## mod_tile therefore offers the ability to automatically throttle requests from ip addresses that have
 ## requested a lot of tiles.
 ## The mechanism uses a token bucket approach to shape traffic. I.e. there is an initial pool of n tiles


### PR DESCRIPTION
I fixed a few typos, and brought over some config examples
from mod_tile.conf into the Debian example debian/tileserver_site.conf
which is deployed as part of the Debian install into /etc/apache2.