### PR TITLE
Configurable ImageIO output format

### DIFF
--- a/examples/config/renderd/renderd.conf.dist
+++ b/examples/config/renderd/renderd.conf.dist
@@ -43,7 +43,7 @@ XML=/var/www/example-map/mapnik.xml
 ;** config options used by mod_tile, but not renderd **
 ;MINZOOM=0
 ;MAXZOOM=18
-;TYPE=png image/png
+;TYPE=png image/png png256 ; Values are: <extension> <mime-type> <output-format> (for more information about output format see https://github.com/mapnik/mapnik/wiki/Image-IO)
 ;DESCRIPTION=This is a description of the tile layer used in the tile json request
 ;ATTRIBUTION=&copy;<a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> and <a href=\"http://wiki.openstreetmap.org/wiki/Contributors\">contributors</a>, <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a>
 ;SERVER_ALIAS=http://localhost/
@@ -62,7 +62,7 @@ XML=/var/www/example-map/mapnik.xml
 ;** config options used by mod_tile, but not renderd **
 ;MINZOOM=0
 ;MAXZOOM=22
-;TYPE=png image/png
+;TYPE=png image/png png256 ; Values are: <extension> <mime-type> <output-format> (for more information about output format see https://github.com/mapnik/mapnik/wiki/Image-IO)
 ;DESCRIPTION=This is a description of the tile layer used in the tile json request
 ;ATTRIBUTION=&copy;<a href=\"http://www.openstreetmap.org/\">OpenStreetMap</a> and <a href=\"http://wiki.openstreetmap.org/wiki/Contributors\">contributors</a>, <a href=\"http://opendatacommons.org/licenses/odbl/\">ODbL</a>
 ;SERVER_ALIAS=http://localhost/

--- a/includes/daemon.h
+++ b/includes/daemon.h
@@ -52,6 +52,7 @@ typedef struct {
     char host[PATH_MAX];
     char htcpip[PATH_MAX];
     char tile_dir[PATH_MAX];
+    char output_format[INILINE_MAX];
     char parameterization[PATH_MAX];
     int tile_px_size;
     double scale_factor;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -837,9 +837,9 @@ int main(int argc, char **argv)
             char* mimeType[INILINE_MAX];
             char* outputFormat[INILINE_MAX];
             
-            strcpy(fileExtension, "png-default");
-            strcpy(mimeType, "image/png-default");
-            strcpy(outputFormat, "png256-default");
+            strcpy(fileExtension, "png");
+            strcpy(mimeType, "image/png");
+            strcpy(outputFormat, "png256");
             
             sscanf(ini_type, "%[^ ] %[^ ] %[^;#]", fileExtension, mimeType, outputFormat);
             

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -828,7 +828,23 @@ int main(int argc, char **argv)
                 exit(7);
             }
             strcpy(maps[iconf].parameterization, ini_parameterize);
-
+            
+            
+            sprintf(buffer, "%s:type", name);
+            char *ini_type = iniparser_getstring(ini, buffer, "png image/png png256");
+            
+            char* fileExtension[INILINE_MAX];
+            char* mimeType[INILINE_MAX];
+            char* outputFormat[INILINE_MAX];
+            
+            strcpy(fileExtension, "png-default");
+            strcpy(mimeType, "image/png-default");
+            strcpy(outputFormat, "png256-default");
+            
+            sscanf(ini_type, "%[^ ] %[^ ] %[^;#]", fileExtension, mimeType, outputFormat);
+            
+            strcpy(maps[iconf].output_format, outputFormat);
+            
             /* Pass this information into the rendering threads,
              * as it is needed to configure mapniks number of connections
              */

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -10,7 +10,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; If not, see http://www.gnu.org/licenses/.
  */
@@ -111,7 +111,7 @@ struct xmlmapconfig {
     int minzoom;
     int maxzoom;
     int ok;
-    parameterize_function_ptr parameterize_function; 
+    parameterize_function_ptr parameterize_function;
     xmlmapconfig() :
         map(256,256) {}
 };
@@ -271,9 +271,9 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char
 
     mapnik::image_32 buf(render_size_tx*map->tilesize, render_size_ty*map->tilesize);
     try {
-        Map map_parameterized = map->map; 
-        if (map->parameterize_function) 
-            map->parameterize_function(map_parameterized, options); 
+        Map map_parameterized = map->map;
+        if (map->parameterize_function)
+            map->parameterize_function(map_parameterized, options);
         mapnik::agg_renderer<mapnik::image_32> ren(map_parameterized,buf,map->scale);
         ren.apply();
     } catch (std::exception const& ex) {
@@ -292,7 +292,6 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char
 #else
             mapnik::image_view<mapnik::image_data_32> vw(xx * map->tilesize, yy * map->tilesize, map->tilesize, map->tilesize, buf.data());
 #endif
-            //tiles.set(xx, yy, save_to_string(vw, "png256"));
             tiles.set(xx, yy, save_to_string(vw, map->output_format));
         }
     }
@@ -330,10 +329,9 @@ static enum protoCmd render(Map &m, const char *tile_dir, char *xmlname, project
 
     mapnik::image_view<mapnik::image_data_32> vw(128, 128, 256, 256, buf.data());
     //std::cout << "Render " << z << " " << x << " " << y << " " << filename << "\n";
-    
-    //mapnik::save_to_file(vw, tmp, "png256");
+
     mapnik::save_to_file(vw, tmp, outputFormat);
-    
+
     if (rename(tmp, filename)) {
         perror(tmp);
         return cmdNotDone;
@@ -505,4 +503,3 @@ void *render_thread(void * arg)
     }
     return NULL;
 }
-

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -1779,6 +1779,7 @@ static const char *load_tile_config(cmd_parms *cmd, void *mconfig, const char *c
     const char * result;
     char fileExtension[INILINE_MAX];
     char mimeType[INILINE_MAX];
+    char outputFormat[INILINE_MAX];
     char * description = NULL;
     char * attribution = NULL;
     char * cors = NULL;
@@ -1840,6 +1841,7 @@ static const char *load_tile_config(cmd_parms *cmd, void *mconfig, const char *c
             strcpy(url,"");
             strcpy(fileExtension,"png");
             strcpy(mimeType,"image/png");
+            strcpy(outputFormat,"png256");
             description = NULL;
             cors = NULL;
             attribution = NULL;
@@ -1872,7 +1874,7 @@ static const char *load_tile_config(cmd_parms *cmd, void *mconfig, const char *c
                     fclose(hini);
                     return "TYPE too long";
                 }
-                if (sscanf(value, "%[^ ] %[^;#]", fileExtension, mimeType) != 2) {
+                if (sscanf(value, "%[^ ] %[^ ] %[^;#]", fileExtension, mimeType, outputFormat) < 2) {
                     if (description) {free(description); description = NULL;} if (attribution) {free(attribution); attribution = NULL;}
                     if (hostnames) {free(hostnames); hostnames = NULL;} if (cors) {free(cors); cors = NULL;}
                     if (tile_dir) {free(tile_dir); tile_dir = NULL; }


### PR DESCRIPTION
Added the possibility to provide ImageIO's output format in the TYPE string of the renderd.conf file.
For instance:
TYPE=png image/png
TYPE=png image/png png256
TYPE=png image/png png24
TYPE=png image/png png

This should be backward compatible with existing renderd.conf files.

(closes #64)