### PR TITLE
mod_tile runs into timeout because renderd does not send a response for low priority queue requests

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -76,7 +76,7 @@ void send_response(struct item *item, enum protoCmd rsp, int render_time) {
 
     while (item) {
         req = &item->req;
-        if ((item->fd != FD_INVALID) && ((req->cmd == cmdRender) || (req->cmd == cmdRenderPrio) || (req->cmd == cmdRenderBulk))) {
+        if ((item->fd != FD_INVALID) && ((req->cmd == cmdRender) || (req->cmd == cmdRenderPrio) || (req->cmd == cmdRenderLow) || (req->cmd == cmdRenderBulk))) {
             req->cmd = rsp;
             //fprintf(stderr, "Sending message %s to %d\n", cmdStr(rsp), item->fd);
             


### PR DESCRIPTION
if you touch `planet-import-complete` and request an existing tile:
- mod_tile will send a command with `cmdRenderLow`
- renderd will queue this request in `queueRequestLow`
- however when the rendering is done renderd will fail to send a response (`cmdRenderLow` not handled in `send_response`)
- mod_tile will run into a timeout (`ModTileRequestTimeout`) and then serve a tile from file it thinks is outdated but was actually rerendered in the meantime

this PR should fix the issue in `send_response`