### PR TITLE
rely on mapnik 3.0 plugins dir for renderd.conf

### DIFF
--- a/debian/renderd.conf
+++ b/debian/renderd.conf
@@ -5,7 +5,7 @@ num_threads=4
 tile_dir=/var/lib/mod_tile
 
 [mapnik]
-plugins_dir=/usr/lib/mapnik/2.0/input
+plugins_dir=/usr/lib/mapnik/3.0/input
 font_dir=/usr/share/fonts/truetype/ttf-dejavu
 font_dir_recurse=false
 


### PR DESCRIPTION
Trivial PR, but good if one wants to run this on recent operating systems.