### PR TITLE
Fix some spelling errors.

### DIFF
--- a/docs/renderd.8
+++ b/docs/renderd.8
@@ -30,7 +30,7 @@ Set the location of the config file used to configure the various parameters of 
 like the mapnik style sheet. The default is /etc/renderd.conf
 .TP
 \fB\-s\fR|\-\-slave
-Renderd can be used in a distributed fashion accross multiple rendering servers. The master renderd handles queuing and
+Renderd can be used in a distributed fashion across multiple rendering servers. The master renderd handles queuing and
 passes requests to the slaves. This parameter specifies which of the slave sections of renderd.conf applies to this instance
 of renderd. The default is to use the master section
 .TP

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -687,7 +687,7 @@ int main(int argc, char **argv)
         syslog(LOG_ERR, "Failed to initialise request queue");
         exit(1);
     }
-    syslog(LOG_ERR, "Initiating reqyest_queue");
+    syslog(LOG_ERR, "Initiating request_queue");
 
     xmlconfigitem maps[XMLCONFIGS_MAX];
     bzero(maps, sizeof(xmlconfigitem) * XMLCONFIGS_MAX);

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -2412,7 +2412,7 @@ static const command_rec tile_cmds[] =
         mod_tile_cache_lastmod_factor_config,   /* config action routine */
         NULL,                                   /* argument to include in call */
         OR_OPTIONS,                             /* where available */
-        "Set the factor by which the last modified determins cache expiry" /* directive description */
+        "Set the factor by which the last modified determines cache expiry" /* directive description */
     ),
     AP_INIT_TAKE2(
         "ModTileCacheDurationLowZoom",       /* directive name */

--- a/src/protocol_helper.c
+++ b/src/protocol_helper.c
@@ -42,7 +42,7 @@ int recv_cmd(struct protocol * cmd, int fd,  int block) {
         return 0;
     }
     if ((cmd->ver > 3) || (cmd->ver < 1)) {
-        syslog(LOG_WARNING, "WARNING: Failed to recieve render cmd with unknown protocol version %i\n", cmd->ver);
+        syslog(LOG_WARNING, "WARNING: Failed to receive render cmd with unknown protocol version %i\n", cmd->ver);
         return -1;
     }
     syslog(LOG_DEBUG, "DEBUG: Got incoming request with protocol version %i\n", cmd->ver); 


### PR DESCRIPTION
Author: Bas Couwenberg
Origin: [spelling-errors.patch](https://salsa.debian.org/xamanu/libapache2-mod-tile/-/blob/c80f8cc216c0aba38ae3f58e605fc585cfe64441/debian/patches/spelling-errors.patch)

* recieve   -> receive
* accross   -> across
* determins -> determines
* reqyest   -> request
