### PR TITLE
Replace select() by poll().

### DIFF
--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -62,6 +62,7 @@ module AP_MODULE_DECLARE_DATA tile_module;
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <inttypes.h>
+#include <poll.h>
 
 
 #include "gen_tile.h"
@@ -303,16 +304,16 @@ static int request_tile(request_rec *r, struct protocol *cmd, int renderImmediat
 	} while (retry--);
 
 	if (renderImmediately) {
-		struct timeval tv = {(renderImmediately > 2 ? scfg->request_timeout_priority : scfg->request_timeout), 0 };
-		fd_set rx;
+		int timeout = (renderImmediately > 2 ? scfg->request_timeout_priority : scfg->request_timeout);
+		struct pollfd rx;
 		int s;
 
 		while (1) {
-			FD_ZERO(&rx);
-			FD_SET(fd, &rx);
-			s = select(fd + 1, &rx, NULL, NULL, &tv);
+			rx.fd = fd;
+			rx.events = POLLIN;
+			s = poll(&rx, 1, timeout * 1000);
 
-			if (s == 1) {
+			if (s > 0) {
 				bzero(&resp, sizeof(struct protocol));
 				ret = recv(fd, &resp, sizeof(struct protocol_v2), 0);
 
@@ -339,11 +340,17 @@ static int request_tile(request_rec *r, struct protocol *cmd, int renderImmediat
 						      "Response does not match request: xml(%s,%s) z(%d,%d) x(%d,%d) y(%d,%d)", cmd->xmlname,
 						      resp.xmlname, cmd->z, resp.z, cmd->x, resp.x, cmd->y, resp.y);
 				}
-			} else {
+			} else if (s == 0) {
 				ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r,
 					      "request_tile: Request xml(%s) z(%d) x(%d) y(%d) could not be rendered in %i seconds",
 					      cmd->xmlname, cmd->z, cmd->x, cmd->y,
-					      (renderImmediately > 1 ? scfg->request_timeout_priority : scfg->request_timeout));
+					      timeout);
+				break;
+			} else {
+				ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r,
+					      "request_tile: Request xml(%s) z(%d) x(%d) y(%d) timeout %i seconds failed with reason: %s",
+					      cmd->xmlname, cmd->z, cmd->x, cmd->y,
+					      timeout, strerror(errno));
 				break;
 			}
 		}


### PR DESCRIPTION
This is a rebased version of #208 given the original requestor hasn't responded to the request to rebase and we are now running into this on tile.openstreetmap.org:

select() has a well-known limit and the maximum file descriptor
that can be used (FD_SETSIZE). On Linux it is in most cases 1024.

Our renderd uses a lot of planet tiff files, so it had already
more than 1600 FDs for tiff files open. That means any new FD gets a
number bigger than that and using such FDs in select() leads to crashes
(because select() uses a fixed size bitmap).

The same can happen in mod_tile if the surounding web server is very
busy, altough it is less likely to happen there.

Changes in src/mod_tile.c:
- include poll.h
- poll timeout is an int containing miliseconds
- use "s > 0" instead of "s == 1" as success
  (although it should never be >1)
- different log message for timeout and error case

Changes in src/daemon.c:
- remove include for sys/select.h
- replace connections array by new array pfd used in poll()
- include special FDs (exit and listen) at index 0 and 1 in this array
- no longer reorganize array while iteratig through it.
  That would have led to items being skipped.
  Instead mark array slots with fixed connections with
  a negative FD. These are automatically skipped by poll.
  Reuse these slots later when new connections come in.
- rename num_connections to num_cslots (initial segment
  of the array that poll() should check) and
  num_conns (number of slots in this segment, that are
  actually used by connections; this number is only
  used in logging).
- slightly enhance debug log lines