### PR TITLE
Retry a failed command after reconnecting

### DIFF
--- a/src/render_submit_queue.c
+++ b/src/render_submit_queue.c
@@ -264,7 +264,7 @@ void *thread_main(void *arg)
 			break;
 		}
 
-		if (process(cmd, fd) < 1) {
+		while (process(cmd, fd) < 1) {
 			fprintf(stderr, "connection to renderd lost");
 			close(fd);
 			fd = -1;


### PR DESCRIPTION
As noted in https://github.com/openstreetmap/mod_tile/pull/229#pullrequestreview-705434980 my previous fix to reconnect automatically didn't retry the failed command so this adds looping on the command when it fails and we have to reconnect.