### PR TITLE
Minor logging changes

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -917,7 +917,7 @@ int main(int argc, char **argv)
 			maps[iconf].max_zoom = atoi(ini_maxzoom);
 
 			if (maps[iconf].max_zoom > MAX_ZOOM) {
-				g_logger(G_LOG_LEVEL_CRITICAL, "Specified max zoom (%i) is to large. Renderd currently only supports up to zoom level %i", maps[iconf].max_zoom, MAX_ZOOM);
+				g_logger(G_LOG_LEVEL_CRITICAL, "Specified max zoom (%i) is too large. Renderd currently only supports up to zoom level %i", maps[iconf].max_zoom, MAX_ZOOM);
 				exit(7);
 			}
 
@@ -926,7 +926,7 @@ int main(int argc, char **argv)
 			maps[iconf].min_zoom = atoi(ini_minzoom);
 
 			if (maps[iconf].min_zoom < 0) {
-				g_logger(G_LOG_LEVEL_CRITICAL, "Specified min zoom (%i) is to small. Minimum zoom level has to be greater or equal to 0", maps[iconf].min_zoom);
+				g_logger(G_LOG_LEVEL_CRITICAL, "Specified min zoom (%i) is too small. Minimum zoom level has to be greater or equal to 0", maps[iconf].min_zoom);
 				exit(7);
 			}
 

--- a/src/parameterize_style.cpp
+++ b/src/parameterize_style.cpp
@@ -92,11 +92,11 @@ static void parameterize_map_language(mapnik::Map &m, char * parameter)
 
 parameterize_function_ptr init_parameterization_function(char * function_name)
 {
-	g_logger(G_LOG_LEVEL_INFO, "Loading parameterization function for %s", function_name);
-
 	if (strcmp(function_name, "") == 0) {
+		g_logger(G_LOG_LEVEL_DEBUG, "Parameterize_style not specified (or empty string specified)");
 		return NULL;
 	} else if (strcmp(function_name, "language") == 0) {
+		g_logger(G_LOG_LEVEL_INFO, "Loading parameterization function for %s", function_name);
 		return parameterize_map_language;
 	} else {
 		g_logger(G_LOG_LEVEL_WARNING, "unknown parameterization function for %s", function_name);


### PR DESCRIPTION
* Changed logging level for empty/absent `parameterize_style` to `DEBUG`
  * Addresses this message currently being shown once per thread during initialization:
    ```
    ** INFO: 04:05:50.327: Loading parameterization function for
    ```
* Fixed two minor grammar issues: `to` => `too`