### PR TITLE
Allow connections over TCP besides Unix sockets for tools

### DIFF
--- a/includes/protocol.h
+++ b/includes/protocol.h
@@ -35,6 +35,8 @@ extern "C" {
 #define TILE_PATH_MAX (256)
 #define PROTO_VER (3)
 #define RENDER_SOCKET "/run/renderd/renderd.sock"
+#define RENDER_HOST "localhost"
+#define RENDER_PORT 7654
 #define XMLCONFIG_MAX 41
 
 enum protoCmd { cmdIgnore, cmdRender, cmdDirty, cmdDone, cmdNotDone, cmdRenderPrio, cmdRenderBulk, cmdRenderLow };

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -201,7 +201,7 @@ int main(int argc, char **argv)
 				fprintf(stderr, "  -f, --force          render tiles even if they seem current\n");
 				fprintf(stderr, "  -m, --map=MAP        render tiles in this map (defaults to '" XMLCONFIG_DEFAULT "')\n");
 				fprintf(stderr, "  -l, --max-load=LOAD  sleep if load is this high (defaults to %d)\n", MAX_LOAD_OLD);
-				fprintf(stderr, "  -s, --socket=SOCKET  unix domain socket name for contacting renderd\n");
+				fprintf(stderr, "  -s, --socket=SOCKET|HOSTNAME:PORT  unix domain socket name or hostname and port for contacting renderd\n");
 				fprintf(stderr, "  -n, --num-threads=N the number of parallel request threads (default 1)\n");
 				fprintf(stderr, "  -t, --tile-dir       tile cache directory (defaults to '" HASH_PATH "')\n");
 				fprintf(stderr, "  -z, --min-zoom=ZOOM  filter input to only render tiles greater or equal to this zoom level (default is 0)\n");


### PR DESCRIPTION
Signed-off-by: Stephan Austermühle <au@hcsd.de>

Fixes #137 

This PR allows tools like `render_list` to connect to `renderd` over network instead of local Unix sockets allowing for easy separation of `mod_tile` and `renderd`. Also, it enables connecting to dynamically scaling `renderd` instances (e.g., when deployed on a Kubernetes cluster). Simply pass `-s ‹hostname›:‹tcpPort›` instead of a Unix socket path to use.

Feedback on this PR is welcome.