### PR TITLE
Enable TCP keepalives for render_list connections to renderd

### DIFF
--- a/includes/protocol.h
+++ b/includes/protocol.h
@@ -39,6 +39,16 @@ extern "C" {
 #define RENDER_PORT 7654
 #define XMLCONFIG_MAX 41
 
+/* TCP keepalive configuration */
+struct keepalive_settings {
+  int enabled;
+	int time;
+	int interval;
+	int probes;
+};
+
+extern struct keepalive_settings keepalives;
+
 enum protoCmd { cmdIgnore, cmdRender, cmdDirty, cmdDone, cmdNotDone, cmdRenderPrio, cmdRenderBulk, cmdRenderLow };
 
 struct protocol {

--- a/src/render_expired.c
+++ b/src/render_expired.c
@@ -61,6 +61,8 @@ int main(int argc, char **argv)
 }
 #else
 
+struct keepalive_settings keepalives;
+
 // tile marking arrays
 unsigned int **tile_requested;
 
@@ -108,6 +110,8 @@ int main(int argc, char **argv)
 	int i;
 	struct storage_backend * store;
 	char name[PATH_MAX];
+
+	memset(&keepalives, 0, sizeof(struct keepalive_settings));
 
 	// excess_zoomlevels is how many zoom levels at the large end
 	// we can ignore because their tiles will share one meta tile.

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -95,9 +95,6 @@ int main(int argc, char **argv)
 	struct stat_info s;
 
 	memset(&keepalives, 0, sizeof(struct keepalive_settings));
-	keepalives.time = 60;
-	keepalives.interval = 60;
-	keepalives.probes = 9;
 
 	while (1) {
 		int option_index = 0;
@@ -110,6 +107,7 @@ int main(int argc, char **argv)
 			{"max-y", required_argument, 0, 'Y'},
 			{"socket", required_argument, 0, 's'},
 			{"keepalives", no_argument, 0, 'k'},
+			{"keepalive-config", required_argument, 0, 'K'},
 			{"num-threads", required_argument, 0, 'n'},
 			{"max-load", required_argument, 0, 'l'},
 			{"tile-dir", required_argument, 0, 't'},
@@ -121,7 +119,7 @@ int main(int argc, char **argv)
 			{0, 0, 0, 0}
 		};
 
-		c = getopt_long(argc, argv, "hvaz:Z:x:X:y:Y:s:km:t:n:l:f", long_options, &option_index);
+		c = getopt_long(argc, argv, "hvaz:Z:x:X:y:Y:s:kK:m:t:n:l:f", long_options, &option_index);
 
 		if (c == -1) {
 			break;
@@ -140,6 +138,50 @@ int main(int argc, char **argv)
 			case 'k':		/* -k, --keepalives */
 			  keepalives.enabled = 1;
 				break;
+
+			case 'K': {  /* --keepalive-config=<t>:<intvl>:<count> */
+				char * confstr = strdup(optarg);
+				if (!strlen(confstr)) {
+					fprintf(stderr, "No parameters provided for the TCP keepalive config\n");
+					return 1;
+				}
+
+				int val_count = 0;
+				const int val_count_expected = 3;
+				char * val[val_count_expected];
+				char * p = strtok(confstr, ":");
+				while (p != NULL) {
+					val[ val_count++ ] = p;
+					p = strtok(NULL, ":");
+				}
+
+				if (val_count != val_count_expected) {
+					fprintf(stderr, "Must provide exactly %d instead of %d arguments to --kepalive-config. See help for details.\n", val_count_expected, val_count);
+					return 1;
+				}
+
+				keepalives.enabled = 1;
+				char * error_char = NULL;
+				keepalives.time = strtol(val[0], &error_char, 10);
+				if (*error_char != '\0') {
+					fprintf(stderr, "TCP keepalive time contains invalid character\n");
+					return 1;
+				}
+
+				keepalives.interval = strtol(val[1], &error_char, 10);
+				if (*error_char != '\0') {
+					fprintf(stderr, "TCP keepalive interval contains invalid character\n");
+					return 1;
+				}
+
+				keepalives.probes = strtol(val[2], &error_char, 10);
+				if (*error_char != '\0') {
+					fprintf(stderr, "TCP keepalive probe count contains invalid character\n");
+					return 1;
+				}
+
+			  break;
+			}
 
 			case 't':   /* -t, --tile-dir */
 				tile_dir = strdup(optarg);
@@ -214,7 +256,8 @@ int main(int argc, char **argv)
 				fprintf(stderr, "  -m, --map=MAP        render tiles in this map (defaults to '" XMLCONFIG_DEFAULT "')\n");
 				fprintf(stderr, "  -l, --max-load=LOAD  sleep if load is this high (defaults to %d)\n", MAX_LOAD_OLD);
 				fprintf(stderr, "  -s, --socket=SOCKET|HOSTNAME:PORT  unix domain socket name or hostname and port for contacting renderd\n");
-				fprintf(stderr, "  -k, --keepalives     enable TCP keepalives");
+				fprintf(stderr, "  -k, --keepalives     enable TCP keepalives\n");
+				fprintf(stderr, "  -K, --keepalive-config=<t>:<intvl>:<count>  TCP keepalive configuration. Send keepalives after t seconds of inactivity, every intvl seconds. Consider connection broken after count probes. Implicitly enables TCP keepalives.\n");
 				fprintf(stderr, "  -n, --num-threads=N the number of parallel request threads (default 1)\n");
 				fprintf(stderr, "  -t, --tile-dir       tile cache directory (defaults to '" HASH_PATH "')\n");
 				fprintf(stderr, "  -z, --min-zoom=ZOOM  filter input to only render tiles greater or equal to this zoom level (default is 0)\n");

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -52,6 +52,8 @@ int main(int argc, char **argv)
 }
 #else
 
+struct keepalive_settings keepalives;
+
 static int minZoom = 0;
 static int maxZoom = MAX_ZOOM;
 static int verbose = 0;
@@ -92,6 +94,11 @@ int main(int argc, char **argv)
 	struct storage_backend * store;
 	struct stat_info s;
 
+	memset(&keepalives, 0, sizeof(struct keepalive_settings));
+	keepalives.time = 60;
+	keepalives.interval = 60;
+	keepalives.probes = 9;
+
 	while (1) {
 		int option_index = 0;
 		static struct option long_options[] = {
@@ -102,6 +109,7 @@ int main(int argc, char **argv)
 			{"min-y", required_argument, 0, 'y'},
 			{"max-y", required_argument, 0, 'Y'},
 			{"socket", required_argument, 0, 's'},
+			{"keepalives", no_argument, 0, 'k'},
 			{"num-threads", required_argument, 0, 'n'},
 			{"max-load", required_argument, 0, 'l'},
 			{"tile-dir", required_argument, 0, 't'},
@@ -113,7 +121,7 @@ int main(int argc, char **argv)
 			{0, 0, 0, 0}
 		};
 
-		c = getopt_long(argc, argv, "hvaz:Z:x:X:y:Y:s:m:t:n:l:f", long_options, &option_index);
+		c = getopt_long(argc, argv, "hvaz:Z:x:X:y:Y:s:km:t:n:l:f", long_options, &option_index);
 
 		if (c == -1) {
 			break;
@@ -127,6 +135,10 @@ int main(int argc, char **argv)
 			case 's':   /* -s, --socket */
 				free(spath);
 				spath = strdup(optarg);
+				break;
+
+			case 'k':		/* -k, --keepalives */
+			  keepalives.enabled = 1;
 				break;
 
 			case 't':   /* -t, --tile-dir */
@@ -202,6 +214,7 @@ int main(int argc, char **argv)
 				fprintf(stderr, "  -m, --map=MAP        render tiles in this map (defaults to '" XMLCONFIG_DEFAULT "')\n");
 				fprintf(stderr, "  -l, --max-load=LOAD  sleep if load is this high (defaults to %d)\n", MAX_LOAD_OLD);
 				fprintf(stderr, "  -s, --socket=SOCKET|HOSTNAME:PORT  unix domain socket name or hostname and port for contacting renderd\n");
+				fprintf(stderr, "  -k, --keepalives     enable TCP keepalives");
 				fprintf(stderr, "  -n, --num-threads=N the number of parallel request threads (default 1)\n");
 				fprintf(stderr, "  -t, --tile-dir       tile cache directory (defaults to '" HASH_PATH "')\n");
 				fprintf(stderr, "  -z, --min-zoom=ZOOM  filter input to only render tiles greater or equal to this zoom level (default is 0)\n");

--- a/src/render_old.c
+++ b/src/render_old.c
@@ -65,7 +65,7 @@ static struct timeval start, end;
 
 int foreground = 1;
 
-
+struct keepalive_settings keepalives;
 
 void display_rate(struct timeval start, struct timeval end, int num)
 {
@@ -198,6 +198,8 @@ int main(int argc, char **argv)
 	int numThreads = 1;
 	int dd, mm, yy;
 	struct tm tm;
+
+	memset(&keepalives, 0, sizeof(struct keepalive_settings));
 
 	while (1) {
 		int option_index = 0;

--- a/src/render_submit_queue.c
+++ b/src/render_submit_queue.c
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <netdb.h>
+#include <netinet/tcp.h>
 #include <pthread.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -306,10 +307,45 @@ int make_connection(const char *spath)
 				continue;
 			}
 
+			if (keepalives.enabled) {
+				fprintf(stderr, "Enabling TCP keepalives\n");
+				int optval = 0;
+				socklen_t optlen = sizeof(optval);
+
+				optval = 1;
+				if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &optval, sizeof(optval)) < 0) {
+						perror("setsockopt()");
+						close(fd);
+						exit(2);
+				}
+
+#ifdef LINUX
+				if (keepalives.time > 0 && setsockopt(fd, SOL_SOCKET, TCP_KEEPIDLE, &keepalives.time, sizeof(keepalives.time)) < 0) {
+						perror("setsockopt()");
+						close(fd);
+						exit(2);
+				}
+
+				if (keepalives.interval > 0 && setsockopt(fd, SOL_SOCKET, TCP_KEEPINTVL, &keepalives.interval, sizeof(keepalives.interval)) < 0) {
+						perror("setsockopt()");
+						close(fd);
+						exit(2);
+				}
+
+				if (keepalives.probes > 0 && setsockopt(fd, SOL_SOCKET, TCP_KEEPCNT, &keepalives.probes, sizeof(keepalives.probes)) < 0) {
+						perror("setsockopt()");
+						close(fd);
+						exit(2);
+				}
+#endif
+
+			}
+
 			char resolved_addr[NI_MAXHOST];
 			char resolved_port[NI_MAXSERV];
 			int name_info = getnameinfo(rp->ai_addr, rp->ai_addrlen, resolved_addr, sizeof(resolved_addr), resolved_port, sizeof(resolved_port), NI_NUMERICHOST | NI_NUMERICSERV);
 			if (name_info != 0) {
+				close(fd);
 				fprintf(stderr, "cannot retrieve name info: %d\n", name_info);
 				exit(2);
 			}

--- a/src/render_submit_queue.c
+++ b/src/render_submit_queue.c
@@ -309,6 +309,13 @@ int make_connection(const char *spath)
 
 			if (keepalives.enabled) {
 				fprintf(stderr, "Enabling TCP keepalives\n");
+				if (keepalives.time > 0) {
+					fprintf(stderr, "TCP keepalives configuration: time=%d, interval=%d, probes=%d\n",
+						keepalives.time,
+						keepalives.interval,
+						keepalives.probes
+					);
+				}
 				int optval = 0;
 				socklen_t optlen = sizeof(optval);
 

--- a/src/speedtest.cpp
+++ b/src/speedtest.cpp
@@ -49,6 +49,8 @@ int main(int argc, char **argv)
 }
 #else
 
+struct keepalive_settings keepalives;
+
 static const int minZoom = 0;
 static const int maxZoom = 18;
 
@@ -207,6 +209,8 @@ int main(int argc, char **argv)
 	const char * mapname = "default";
 	int verbose = 0;
 	int numThreads = 1;
+
+	memset(&keepalives, 0, sizeof(struct keepalive_settings));
 
 	while (1) {
 		int option_index = 0;


### PR DESCRIPTION
This PR allows enabling and customizing TCP keepalives to better cope with load balancers silently closing connections.

Feedback is welcome.

Fixes #263 