### PR TITLE
Make `/status` and `/dirty` URLs controlable with apache conf (& default disable)

### DIFF
--- a/etc/apache2/renderd-example-map.conf
+++ b/etc/apache2/renderd-example-map.conf
@@ -142,12 +142,12 @@ Listen 8081
 
     # Enable the .../Z/X/Y.ext/status URL, which shows details of that tile.
     # Off = a 404 is returned for that url instead.
-    # Default: On
+    # Default: Off
     #ModTileEnableStatusURL On
 
     # Enable the .../Z/X/Y.ext/dirty URL, which shows details of that tile.
     # Off = a 404 is returned for that url instead.
-    # Default: On
+    # Default: Off
     #ModTileEnableDirtyURL On
 
 </VirtualHost>

--- a/etc/apache2/renderd-example-map.conf
+++ b/etc/apache2/renderd-example-map.conf
@@ -140,4 +140,9 @@ Listen 8081
     # Parameters (poolsize in tiles and topup rate in tiles per second) for throttling render requests.
     ModTileThrottlingRenders 128 0.2
 
+    # Enable the .../Z/X/Y.ext/status URL, which shows details of that tile.
+    # Off = a 404 is returned for that url instead.
+    # Default: On
+    #ModTileEnableStatusURL On
+
 </VirtualHost>

--- a/etc/apache2/renderd-example-map.conf
+++ b/etc/apache2/renderd-example-map.conf
@@ -145,4 +145,9 @@ Listen 8081
     # Default: On
     #ModTileEnableStatusURL On
 
+    # Enable the .../Z/X/Y.ext/dirty URL, which shows details of that tile.
+    # Off = a 404 is returned for that url instead.
+    # Default: On
+    #ModTileEnableDirtyURL On
+
 </VirtualHost>

--- a/includes/mod_tile.h
+++ b/includes/mod_tile.h
@@ -137,6 +137,7 @@ typedef struct {
 	long delaypoolRenderRate;
 	int bulkMode;
 	int enableStatusUrl;
+	int enableDirtyUrl;
 } tile_server_conf;
 
 typedef struct tile_request_data {

--- a/includes/mod_tile.h
+++ b/includes/mod_tile.h
@@ -136,6 +136,7 @@ typedef struct {
 	int delaypoolRenderSize;
 	long delaypoolRenderRate;
 	int bulkMode;
+	int enableStatusUrl;
 } tile_server_conf;
 
 typedef struct tile_request_data {

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -2775,8 +2775,8 @@ static void *create_tile_config(apr_pool_t *p, server_rec *s)
 	scfg->delaypoolRenderSize = AVAILABLE_RENDER_BUCKET_SIZE;
 	scfg->delaypoolRenderRate = RENDER_TOPUP_RATE;
 	scfg->bulkMode = 0;
-	scfg->enableStatusUrl = 1;	// By default, enable this feature
-	scfg->enableDirtyUrl = 1;	// By default, enable this feature
+	scfg->enableStatusUrl = 0;
+	scfg->enableDirtyUrl = 0;
 
 
 	return scfg;

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -989,6 +989,10 @@ static int tile_handler_dirty(request_rec *r)
 	sconf = r->server->module_config;
 	scfg = ap_get_module_config(sconf, &tile_module);
 
+	if (!scfg->enableDirtyUrl) {
+		return HTTP_NOT_FOUND;
+	}
+
 	if (scfg->bulkMode) {
 		return OK;
 	}
@@ -2685,6 +2689,13 @@ static const char *mod_tile_enable_status_url(cmd_parms *cmd, void *mconfig, int
 	return NULL;
 }
 
+static const char *mod_tile_enable_dirty_url(cmd_parms *cmd, void *mconfig, int enableDirtyUrl)
+{
+	tile_server_conf *scfg = ap_get_module_config(cmd->server->module_config, &tile_module);
+	scfg->enableDirtyUrl = enableDirtyUrl;
+	return NULL;
+}
+
 static const char *mod_tile_delaypool_tiles_config(cmd_parms *cmd, void *mconfig, const char *bucketsize_string, const char *topuprate_string)
 {
 	int bucketsize;
@@ -2765,6 +2776,7 @@ static void *create_tile_config(apr_pool_t *p, server_rec *s)
 	scfg->delaypoolRenderRate = RENDER_TOPUP_RATE;
 	scfg->bulkMode = 0;
 	scfg->enableStatusUrl = 1;	// By default, enable this feature
+	scfg->enableDirtyUrl = 1;	// By default, enable this feature
 
 
 	return scfg;
@@ -2808,6 +2820,7 @@ static void *merge_tile_config(apr_pool_t *p, void *basev, void *overridesv)
 	scfg->delaypoolRenderRate = scfg_over->delaypoolRenderRate;
 	scfg->bulkMode = scfg_over->bulkMode;
 	scfg->enableStatusUrl = scfg_over->enableStatusUrl;
+	scfg->enableDirtyUrl = scfg_over->enableDirtyUrl;
 
 	//Construct a table of minimum cache times per zoom level
 	for (i = 0; i <= MAX_ZOOM_SERVER; i++) {
@@ -3005,6 +3018,13 @@ static const command_rec tile_cmds[] = {
 		NULL,                            /* argument to include in call */
 		OR_OPTIONS,                      /* where available */
 		"On Off - whether to handle .../status urls "  /* directive description */
+	),
+	AP_INIT_FLAG(
+		"ModTileEnableDirtyURL",         /* directive name */
+		mod_tile_enable_dirty_url,       /* config action routine */
+		NULL,                            /* argument to include in call */
+		OR_OPTIONS,                      /* where available */
+		"On Off - whether to handle .../dirty urls "  /* directive description */
 	),
 	{NULL}
 };


### PR DESCRIPTION
This patch makes the `/status` & `/dirty` URL requests diabled by default, and allows one to turn it on or off with `ModTileStatusURL On`/`ModTileDirtyURL On`. It implements #272. I am not opposed to “default on” (which is the current behaviour)

I am very rust with C, so I highly encourage anyone to look at this and tell me if I'm doing something very wrong. I am in the early stages of testing this patch in production, so I suggest not merging it today.