### PR TITLE
Resolve various compiler warnings and errors

### DIFF
--- a/includes/daemon.h
+++ b/includes/daemon.h
@@ -34,16 +34,16 @@ int daemon(int nochdir, int noclose);
 #define MAX_SLAVES 5
 
 typedef struct {
-	char *socketname;
-	char *iphostname;
+	const char *iphostname;
+	const char *mapnik_font_dir;
+	const char *mapnik_plugins_dir;
+	const char *pid_filename;
+	const char *socketname;
+	const char *stats_filename;
+	const char *tile_dir;
 	int ipport;
-	int num_threads;
-	char *tile_dir;
-	char *mapnik_plugins_dir;
-	char *mapnik_font_dir;
 	int mapnik_font_dir_recurse;
-	char * stats_filename;
-	const char * pid_filename;
+	int num_threads;
 } renderd_config;
 
 typedef struct {

--- a/src/cache_expire.c
+++ b/src/cache_expire.c
@@ -115,7 +115,7 @@ void cache_expire(int sock, char * host, char * uri, int x, int y, int z)
 	}
 
 	char * url = (char *)malloc(1024);
-	snprintf(url, sizeof(url), "http://%s%s%i/%i/%i.png", host, uri, z, x, y);
+	snprintf(url, 1024, "http://%s%s%i/%i/%i.png", host, uri, z, x, y);
 	cache_expire_url(sock, url);
 	free(url);
 }

--- a/src/cache_expire.c
+++ b/src/cache_expire.c
@@ -115,7 +115,7 @@ void cache_expire(int sock, char * host, char * uri, int x, int y, int z)
 	}
 
 	char * url = (char *)malloc(1024);
-	sprintf(url, "http://%s%s%i/%i/%i.png", host, uri, z, x, y);
+	snprintf(url, sizeof(url), "http://%s%s%i/%i/%i.png", host, uri, z, x, y);
 	cache_expire_url(sock, url);
 	free(url);
 }

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -831,7 +831,7 @@ int main(int argc, char **argv)
 	char buffer[PATH_MAX];
 
 	for (int section = 0; section < iniparser_getnsec(ini); section++) {
-		char *name = iniparser_getsecname(ini, section);
+		const char *name = iniparser_getsecname(ini, section);
 		g_logger(G_LOG_LEVEL_INFO, "Parsing section %s", name);
 
 		if (strncmp(name, "renderd", 7) && strcmp(name, "mapnik")) {
@@ -856,7 +856,7 @@ int main(int argc, char **argv)
 			strcpy(maps[iconf].xmlname, name);
 
 			sprintf(buffer, "%s:uri", name);
-			char *ini_uri = iniparser_getstring(ini, buffer, (char *)"");
+			const char *ini_uri = iniparser_getstring(ini, buffer, (char *)"");
 
 			if (strlen(ini_uri) >= (PATH_MAX - 1)) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "URI too long: %s", ini_uri);
@@ -866,7 +866,7 @@ int main(int argc, char **argv)
 			strcpy(maps[iconf].xmluri, ini_uri);
 
 			sprintf(buffer, "%s:xml", name);
-			char *ini_xmlpath = iniparser_getstring(ini, buffer, (char *)"");
+			const char *ini_xmlpath = iniparser_getstring(ini, buffer, (char *)"");
 
 			if (strlen(ini_xmlpath) >= (PATH_MAX - 1)) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "XML path too long: %s", ini_xmlpath);
@@ -876,7 +876,7 @@ int main(int argc, char **argv)
 			strcpy(maps[iconf].xmlfile, ini_xmlpath);
 
 			sprintf(buffer, "%s:host", name);
-			char *ini_hostname = iniparser_getstring(ini, buffer, (char *) "");
+			const char *ini_hostname = iniparser_getstring(ini, buffer, (char *) "");
 
 			if (strlen(ini_hostname) >= (PATH_MAX - 1)) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "Host name too long: %s", ini_hostname);
@@ -886,7 +886,7 @@ int main(int argc, char **argv)
 			strcpy(maps[iconf].host, ini_hostname);
 
 			sprintf(buffer, "%s:htcphost", name);
-			char *ini_htcpip = iniparser_getstring(ini, buffer, (char *) "");
+			const char *ini_htcpip = iniparser_getstring(ini, buffer, (char *) "");
 
 			if (strlen(ini_htcpip) >= (PATH_MAX - 1)) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "HTCP host name too long: %s", ini_htcpip);
@@ -896,7 +896,7 @@ int main(int argc, char **argv)
 			strcpy(maps[iconf].htcpip, ini_htcpip);
 
 			sprintf(buffer, "%s:tilesize", name);
-			char *ini_tilesize = iniparser_getstring(ini, buffer, (char *) "256");
+			const char *ini_tilesize = iniparser_getstring(ini, buffer, (char *) "256");
 			maps[iconf].tile_px_size = atoi(ini_tilesize);
 
 			if (maps[iconf].tile_px_size < 1) {
@@ -905,7 +905,7 @@ int main(int argc, char **argv)
 			}
 
 			sprintf(buffer, "%s:scale", name);
-			char *ini_scale = iniparser_getstring(ini, buffer, (char *) "1.0");
+			const char *ini_scale = iniparser_getstring(ini, buffer, (char *) "1.0");
 			maps[iconf].scale_factor = atof(ini_scale);
 
 			if (maps[iconf].scale_factor < 0.1 || maps[iconf].scale_factor > 8.0) {
@@ -914,7 +914,7 @@ int main(int argc, char **argv)
 			}
 
 			sprintf(buffer, "%s:tiledir", name);
-			char *ini_tiledir = iniparser_getstring(ini, buffer, (char *) config.tile_dir);
+			const char *ini_tiledir = iniparser_getstring(ini, buffer, (char *) config.tile_dir);
 
 			if (strlen(ini_tiledir) >= (PATH_MAX - 1)) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "Tiledir too long: %s", ini_tiledir);
@@ -924,7 +924,7 @@ int main(int argc, char **argv)
 			strcpy(maps[iconf].tile_dir, ini_tiledir);
 
 			sprintf(buffer, "%s:maxzoom", name);
-			char *ini_maxzoom = iniparser_getstring(ini, buffer, "18");
+			const char *ini_maxzoom = iniparser_getstring(ini, buffer, "18");
 			maps[iconf].max_zoom = atoi(ini_maxzoom);
 
 			if (maps[iconf].max_zoom > MAX_ZOOM) {
@@ -933,7 +933,7 @@ int main(int argc, char **argv)
 			}
 
 			sprintf(buffer, "%s:minzoom", name);
-			char *ini_minzoom = iniparser_getstring(ini, buffer, "0");
+			const char *ini_minzoom = iniparser_getstring(ini, buffer, "0");
 			maps[iconf].min_zoom = atoi(ini_minzoom);
 
 			if (maps[iconf].min_zoom < 0) {
@@ -947,7 +947,7 @@ int main(int argc, char **argv)
 			}
 
 			sprintf(buffer, "%s:parameterize_style", name);
-			char *ini_parameterize = iniparser_getstring(ini, buffer, "");
+			const char *ini_parameterize = iniparser_getstring(ini, buffer, "");
 
 			if (strlen(ini_parameterize) >= (PATH_MAX - 1)) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "Parameterize_style too long: %s", ini_parameterize);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -855,7 +855,7 @@ int main(int argc, char **argv)
 
 			strcpy(maps[iconf].xmlname, name);
 
-			sprintf(buffer, "%s:uri", name);
+			snprintf(buffer, sizeof(buffer), "%s:uri", name);
 			const char *ini_uri = iniparser_getstring(ini, buffer, (char *)"");
 
 			if (strlen(ini_uri) >= (PATH_MAX - 1)) {
@@ -865,7 +865,7 @@ int main(int argc, char **argv)
 
 			strcpy(maps[iconf].xmluri, ini_uri);
 
-			sprintf(buffer, "%s:xml", name);
+			snprintf(buffer, sizeof(buffer), "%s:xml", name);
 			const char *ini_xmlpath = iniparser_getstring(ini, buffer, (char *)"");
 
 			if (strlen(ini_xmlpath) >= (PATH_MAX - 1)) {
@@ -875,7 +875,7 @@ int main(int argc, char **argv)
 
 			strcpy(maps[iconf].xmlfile, ini_xmlpath);
 
-			sprintf(buffer, "%s:host", name);
+			snprintf(buffer, sizeof(buffer), "%s:host", name);
 			const char *ini_hostname = iniparser_getstring(ini, buffer, (char *) "");
 
 			if (strlen(ini_hostname) >= (PATH_MAX - 1)) {
@@ -885,7 +885,7 @@ int main(int argc, char **argv)
 
 			strcpy(maps[iconf].host, ini_hostname);
 
-			sprintf(buffer, "%s:htcphost", name);
+			snprintf(buffer, sizeof(buffer), "%s:htcphost", name);
 			const char *ini_htcpip = iniparser_getstring(ini, buffer, (char *) "");
 
 			if (strlen(ini_htcpip) >= (PATH_MAX - 1)) {
@@ -895,7 +895,7 @@ int main(int argc, char **argv)
 
 			strcpy(maps[iconf].htcpip, ini_htcpip);
 
-			sprintf(buffer, "%s:tilesize", name);
+			snprintf(buffer, sizeof(buffer), "%s:tilesize", name);
 			const char *ini_tilesize = iniparser_getstring(ini, buffer, (char *) "256");
 			maps[iconf].tile_px_size = atoi(ini_tilesize);
 
@@ -904,7 +904,7 @@ int main(int argc, char **argv)
 				exit(7);
 			}
 
-			sprintf(buffer, "%s:scale", name);
+			snprintf(buffer, sizeof(buffer), "%s:scale", name);
 			const char *ini_scale = iniparser_getstring(ini, buffer, (char *) "1.0");
 			maps[iconf].scale_factor = atof(ini_scale);
 
@@ -913,7 +913,7 @@ int main(int argc, char **argv)
 				exit(7);
 			}
 
-			sprintf(buffer, "%s:tiledir", name);
+			snprintf(buffer, sizeof(buffer), "%s:tiledir", name);
 			const char *ini_tiledir = iniparser_getstring(ini, buffer, (char *) config.tile_dir);
 
 			if (strlen(ini_tiledir) >= (PATH_MAX - 1)) {
@@ -923,7 +923,7 @@ int main(int argc, char **argv)
 
 			strcpy(maps[iconf].tile_dir, ini_tiledir);
 
-			sprintf(buffer, "%s:maxzoom", name);
+			snprintf(buffer, sizeof(buffer), "%s:maxzoom", name);
 			const char *ini_maxzoom = iniparser_getstring(ini, buffer, "18");
 			maps[iconf].max_zoom = atoi(ini_maxzoom);
 
@@ -932,7 +932,7 @@ int main(int argc, char **argv)
 				exit(7);
 			}
 
-			sprintf(buffer, "%s:minzoom", name);
+			snprintf(buffer, sizeof(buffer), "%s:minzoom", name);
 			const char *ini_minzoom = iniparser_getstring(ini, buffer, "0");
 			maps[iconf].min_zoom = atoi(ini_minzoom);
 
@@ -946,7 +946,7 @@ int main(int argc, char **argv)
 				exit(7);
 			}
 
-			sprintf(buffer, "%s:parameterize_style", name);
+			snprintf(buffer, sizeof(buffer), "%s:parameterize_style", name);
 			const char *ini_parameterize = iniparser_getstring(ini, buffer, "");
 
 			if (strlen(ini_parameterize) >= (PATH_MAX - 1)) {
@@ -976,21 +976,21 @@ int main(int argc, char **argv)
 				exit(7);
 			}
 
-			sprintf(buffer, "%s:socketname", name);
+			snprintf(buffer, sizeof(buffer), "%s:socketname", name);
 			config_slaves[render_sec].socketname = iniparser_getstring(ini,
 							       buffer, (char *) RENDER_SOCKET);
-			sprintf(buffer, "%s:iphostname", name);
+			snprintf(buffer, sizeof(buffer), "%s:iphostname", name);
 			config_slaves[render_sec].iphostname = iniparser_getstring(ini,
 							       buffer, "");
-			sprintf(buffer, "%s:ipport", name);
+			snprintf(buffer, sizeof(buffer), "%s:ipport", name);
 			config_slaves[render_sec].ipport = iniparser_getint(ini, buffer, 0);
-			sprintf(buffer, "%s:num_threads", name);
+			snprintf(buffer, sizeof(buffer), "%s:num_threads", name);
 			config_slaves[render_sec].num_threads = iniparser_getint(ini,
 								buffer, NUM_THREADS);
-			sprintf(buffer, "%s:tile_dir", name);
+			snprintf(buffer, sizeof(buffer), "%s:tile_dir", name);
 			config_slaves[render_sec].tile_dir = iniparser_getstring(ini,
 							     buffer, (char *) HASH_PATH);
-			sprintf(buffer, "%s:stats_file", name);
+			snprintf(buffer, sizeof(buffer), "%s:stats_file", name);
 			config_slaves[render_sec].stats_filename = iniparser_getstring(ini,
 					buffer, NULL);
 			snprintf(buffer, sizeof(buffer), "%s:pid_file", name);

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -325,7 +325,7 @@ static int request_tile(request_rec *r, struct protocol *cmd, int renderImmediat
 
 				if (ret != sizeof(struct protocol_v2)) {
 					ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r, "request_tile: Failed to read response from rendering socket. Got %d bytes but expected %d. Errno %d (%s)",
-						      ret, sizeof(struct protocol_v2), errno, strerror(errno));
+						      ret, (int) sizeof(struct protocol_v2), errno, strerror(errno));
 					break;
 				}
 

--- a/src/parameterize_style.cpp
+++ b/src/parameterize_style.cpp
@@ -40,6 +40,7 @@ static void parameterize_map_language(mapnik::Map &m, char * parameter)
 	tok = strtok(data, ",");
 
 	if (!tok) {
+		free(data);
 		return;        //No parameterization given
 	}
 

--- a/src/store_rados.c
+++ b/src/store_rados.c
@@ -352,6 +352,8 @@ struct storage_backend * init_storage_rados(const char * connection_string)
 	int i;
 
 	if (ctx == NULL) {
+		free(ctx);
+		free(store);
 		return NULL;
 	}
 


### PR DESCRIPTION
* Resolved `cppcheck` error `memleak` in `src/store_rados.c`
  * `store` was not being `free`d (see [here](https://github.com/hummeltech/mod_tile/blob/a14924a999d0c465a023c02301964c41700744f1/src/store_rados.c#L354-L356))
* Resolved `cppcheck` error `memleak` in `src/parameterize_style.cpp`
  * `data` was not being `free`d (see [here](https://github.com/hummeltech/mod_tile/blob/a14924a999d0c465a023c02301964c41700744f1/src/parameterize_style.cpp#L42-L44))
* Resolved all compiler warnings `discarded-qualifiers` in `src/daemon.c`
  * Warnings can be seen [here](https://github.com/openstreetmap/mod_tile/runs/6538303841?check_suite_focus=true#step:9:327)
* Resolved compiler warning `format=` in `src/mod_tile.c`
  * Warning can be seen [here](https://github.com/openstreetmap/mod_tile/runs/6538303841?check_suite_focus=true#step:9:930)
* Resolved `flawfinder` error `sprintf: Does not check for buffer overflows (CWE-120)` in `src/daemon.c` & `src/cache_expire.c`