### PR TITLE
Don't use dot-prefixed (I.E. current directory) paths for Flawfinder scan

### DIFF
--- a/.github/workflows/flawfinder-analysis.yml
+++ b/.github/workflows/flawfinder-analysis.yml
@@ -27,7 +27,7 @@ jobs:
       - name: flawfinder_scan
         uses: david-a-wheeler/flawfinder@2.0.19
         with:
-          arguments: '--sarif ./'
+          arguments: '--sarif includes src'
           output: 'flawfinder_results.sarif'
 
       - name: Upload analysis results to GitHub Security tab


### PR DESCRIPTION
This allows the relevant lines to be highlighted for more easily visualizing the issues.

**Before:**
![image](https://user-images.githubusercontent.com/6109326/171051095-54dacbd8-4a9e-4f72-ad5c-61a112a9d980.png)

**After:**
![image](https://user-images.githubusercontent.com/6109326/171051459-e3cb6b8c-3f70-4aeb-8994-8720159116a3.png)
