### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,7 @@ special hashed directory structure. These combine 8x8 actual tiles into a
 single metatile file. This is a more efficient use of disk space and inodes.
 
 The metatiles are then stored in the following directory structure:
-``/[base_dir]/[TileSetName]/[Z]/[xxxxyyyy]/[xxxxyyyy]/[xxxxyyyy]/[xxxxyyyy]/[xxxxyyyy].png``
+``/[base_dir]/[TileSetName]/[Z]/[xxxxyyyy]/[xxxxyyyy]/[xxxxyyyy]/[xxxxyyyy]/[xxxxyyyy].meta``
 
 Where ``base_dir`` is a configurable base path for all tiles. ``TileSetName``
 is the name of the style sheet rendered. ``Z`` is the zoom level.
@@ -190,7 +190,7 @@ also provides built-in features to scale to multi server rendering set-ups.
 Copyright and copyleft
 ----------------------
 
-Copyright (c) 2007 - 2021 by mod_tile contributors (see `AUTHORS <./AUTHORS>`__)
+Copyright (c) 2007 - 2022 by mod_tile contributors (see `AUTHORS <./AUTHORS>`__)
 
 This program is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the


### PR DESCRIPTION
Fix minor typo - as implied by the rest of the text, the tiles on disk are .meta not .png.
Also nudged copyright date to 2022.