### PR TITLE
Increase XMLCONFIGS_MAX

### DIFF
--- a/includes/daemon.h
+++ b/includes/daemon.h
@@ -46,7 +46,7 @@ typedef struct {
 	int num_threads;
 } renderd_config;
 
-typedef struct {
+typedef struct xmlconfigitem {
 	char xmlname[XMLCONFIG_MAX];
 	char xmlfile[PATH_MAX];
 	char xmluri[PATH_MAX];

--- a/includes/gen_tile.h
+++ b/includes/gen_tile.h
@@ -18,6 +18,7 @@
 #ifndef GEN_TILE_H
 #define GEN_TILE_H
 
+#include "daemon.h"
 #include "protocol.h"
 
 #ifdef __cplusplus
@@ -37,6 +38,11 @@ struct item {
 	enum queueEnum inQueue;
 	enum queueEnum originatedQueue;
 };
+
+typedef struct {
+	int num_maps;
+	struct xmlconfigitem *maps;
+} render_thread_args;
 
 //int render(Map &m, int x, int y, int z, const char *filename);
 void *render_thread(void *);

--- a/includes/render_config.h
+++ b/includes/render_config.h
@@ -49,7 +49,7 @@
 // The XML configuration used if one is not provided
 #define XMLCONFIG_DEFAULT "default"
 // Maximum number of configurations that mod tile will allow
-#define XMLCONFIGS_MAX 10
+#define XMLCONFIGS_MAX 100
 // Default PID file path
 #define PIDFILE "/run/renderd/renderd.pid"
 

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -387,12 +387,14 @@ void render_init(const char *plugins_dir, const char* font_dir, int font_dir_rec
 
 void *render_thread(void * arg)
 {
-	xmlconfigitem * parentxmlconfig = (xmlconfigitem *)arg;
-	xmlmapconfig * maps = new xmlmapconfig[XMLCONFIGS_MAX];
+	render_thread_args * parentargs = (render_thread_args *) arg;
+	int num_maps = parentargs->num_maps;
+	xmlconfigitem * parentxmlconfig = parentargs->maps;
+	xmlmapconfig * maps = new xmlmapconfig[num_maps];
 	int i, iMaxConfigs;
 	int render_time;
 
-	for (iMaxConfigs = 0; iMaxConfigs < XMLCONFIGS_MAX; ++iMaxConfigs) {
+	for (iMaxConfigs = 0; iMaxConfigs < num_maps; ++iMaxConfigs) {
 		if (parentxmlconfig[iMaxConfigs].xmlname[0] == 0 || parentxmlconfig[iMaxConfigs].xmlfile[0] == 0) {
 			break;
 		}

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -388,7 +388,7 @@ void render_init(const char *plugins_dir, const char* font_dir, int font_dir_rec
 void *render_thread(void * arg)
 {
 	xmlconfigitem * parentxmlconfig = (xmlconfigitem *)arg;
-	xmlmapconfig maps[XMLCONFIGS_MAX];
+	xmlmapconfig * maps = new xmlmapconfig[XMLCONFIGS_MAX];
 	int i, iMaxConfigs;
 	int render_time;
 
@@ -549,6 +549,13 @@ void *render_thread(void * arg)
 			sleep(1); // TODO: Use an event to indicate there are new requests
 		}
 	}
+
+	for (i = 0; i < iMaxConfigs; ++i) {
+		free(maps[i].prj);
+		free(maps[i].store);
+	}
+
+	delete[] maps;
 
 	return NULL;
 }


### PR DESCRIPTION
Function render_thread() was also modified to allocate memory needed for maps on heap instead of stack, so that we don't use too many stack memory.

I didn't change the stack allocation in main() function, but I can do it if asked, by using a std::vector instead of an array for `xmlconfigitem maps[XMLCONFIGS_MAX];`