### PR TITLE
Fixed typo `HAVE_SYS_CDEFS_C`

### DIFF
--- a/src/daemon_compat.c
+++ b/src/daemon_compat.c
@@ -30,7 +30,7 @@
 #include "config.h"
 #ifndef HAVE_DAEMON
 
-#ifdef HAVE_SYS_CDEFS_C
+#ifdef HAVE_SYS_CDEFS_H
 #include <sys/cdefs.h>
 #endif
 


### PR DESCRIPTION
* It should be `HAVE_SYS_CDEFS_H`
  * From `configure.ac`: (`AC_CHECK_HEADERS([sys/cdefs.h])`)
    * See [here](https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/Generic-Headers.html#index-AC_005fCHECK_005fHEADERS-1) for documentation

Working towards simplifying things in https://github.com/openstreetmap/mod_tile/pull/284.