### PR TITLE
Allow either `iniparser.h` or `iniparser/iniparser.h`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -47,7 +47,7 @@ renderd_SOURCES = \
 	src/protocol_helper.c \
 	$(STORE_SOURCES)
 renderd_CXXFLAGS = $(MAPNIK_CFLAGS)
-renderd_LDADD = $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(STORE_LDFLAGS) -liniparser
+renderd_LDADD = $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(STORE_LDFLAGS) $(INIPARSER_LDFLAGS)
 renderd_DATA = etc/renderd/renderd.conf
 
 render_speedtest_SOURCES = \
@@ -99,7 +99,7 @@ gen_tile_test_SOURCES = \
 	$(STORE_SOURCES)
 gen_tile_test_CFLAGS = -DMAIN_ALREADY_DEFINED $(PTHREAD_CFLAGS) $(GLIB_CFLAGS)
 gen_tile_test_CXXFLAGS = $(MAPNIK_CFLAGS)
-gen_tile_test_LDADD = $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(STORE_LDFLAGS) -liniparser
+gen_tile_test_LDADD = $(PTHREAD_CFLAGS) $(MAPNIK_LDFLAGS) $(STORE_LDFLAGS) $(INIPARSER_LDFLAGS)
 
 CLEANFILES=*.slo mod_tile.la stderr.out src/*.slo src/*.lo src/.libs/* src/*.la
 

--- a/configure.ac
+++ b/configure.ac
@@ -31,7 +31,7 @@ fi
 PKG_CHECK_MODULES([GLIB], [glib-2.0])
 
 # Checks for header files.
-AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stdint.h stdlib.h string.h sys/socket.h sys/time.h syslog.h unistd.h utime.h paths.h sys/cdefs.h sys/loadavg.h])
+AC_CHECK_HEADERS([arpa/inet.h fcntl.h limits.h netdb.h netinet/in.h stdint.h stdlib.h string.h sys/socket.h sys/time.h syslog.h unistd.h utime.h paths.h sys/cdefs.h sys/loadavg.h iniparser.h iniparser/iniparser.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE
@@ -59,6 +59,10 @@ AC_CHECK_LIB(rados, rados_version, [
     LIBRADOS_LDFLAGS='-lrados'
     AC_SUBST(LIBRADOS_LDFLAGS)
 ][])
+AC_CHECK_LIB(iniparser, iniparser_load, [
+    INIPARSER_LDFLAGS='-liniparser'
+    AC_SUBST(INIPARSER_LDFLAGS)
+], [AC_MSG_ERROR([Unable to find libiniparser])])
 
 AC_CHECK_FUNCS([bzero gethostbyname gettimeofday inet_ntoa memset mkdir pow select socket strchr strdup strerror strrchr strstr strtol strtoul utime],[],[AC_MSG_ERROR([One of the required functions was not found])])
 AC_CHECK_FUNCS([daemon getloadavg],[],[])

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -44,10 +44,10 @@
 #include "g_logger.h"
 
 // extern "C" {
-#ifdef __FreeBSD__
-#include <iniparser.h>
-#else
+#ifdef HAVE_INIPARSER_INIPARSER_H
 #include <iniparser/iniparser.h>
+#else
+#include <iniparser.h>
 #endif
 // }
 


### PR DESCRIPTION
* Rather than relying on the OS (I.E. `#ifdef __FreeBSD__`)

Working towards simplifying things in https://github.com/openstreetmap/mod_tile/pull/284.