### PR TITLE
Updated Ubuntu 20.04 doc to fix link to build and test .yml

### DIFF
--- a/docs/build/building_on_ubuntu_20_04.md
+++ b/docs/build/building_on_ubuntu_20_04.md
@@ -1,7 +1,7 @@
 # Building on Ubuntu 20.04
 
 This documents step by step on how to compile and put into use the software `mod_tile` and `renderd`.
-Please see our [Continous Integration script](../../.github/workflows/build-and-test-ubuntu-20-04.yml) for more detail.
+Please see our [Continuous Integration script](../../.github/workflows/build-and-test.yml) for more detail.
 
 ```shell
 #!/usr/bin/env bash


### PR DESCRIPTION
The workflow name is now "build-and-test.yml", so change the 20.04 build doc (which still works for 22.04) to point to that.
Also spelling of "Continuous".