### PR TITLE
Fixed macOS build support

### DIFF
--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -83,7 +83,7 @@ APLOG_USE_MODULE(tile);
 #define APACHE24 1
 #endif
 
-#if defined(__FreeBSD__) && !defined(s6_addr32)
+#if (defined(__FreeBSD__) || defined(__MACH__)) && !defined(s6_addr32)
 #define s6_addr32 __u6_addr.__u6_addr32
 #endif
 


### PR DESCRIPTION
* `s6_addr32` is defined neither in `macOS` nor `FreeBSD`

Working towards simplifying things in https://github.com/openstreetmap/mod_tile/pull/284.