### PR TITLE
Allow `renderd*` sections to follow `map` sections in `renderd.conf`

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -803,14 +803,13 @@ int main(int argc, char **argv)
 
 	g_logger(G_LOG_LEVEL_INFO, "Rendering daemon started (version %s)", VERSION);
 
+	g_logger(G_LOG_LEVEL_INFO, "Initialising request queue");
 	render_request_queue = request_queue_init();
 
 	if (render_request_queue == NULL) {
 		g_logger(G_LOG_LEVEL_CRITICAL, "Failed to initialise request queue");
 		exit(1);
 	}
-
-	g_logger(G_LOG_LEVEL_INFO, "Initialising request_queue");
 
 	xmlconfigitem maps[XMLCONFIGS_MAX];
 	bzero(maps, sizeof(xmlconfigitem) * XMLCONFIGS_MAX);
@@ -819,9 +818,11 @@ int main(int argc, char **argv)
 	bzero(config_slaves, sizeof(renderd_config) * MAX_SLAVES);
 	bzero(&config, sizeof(renderd_config));
 
+	g_logger(G_LOG_LEVEL_INFO, "Parsing config file: %s", config_file_name);
 	dictionary *ini = iniparser_load(config_file_name);
 
-	if (! ini) {
+	if (!ini) {
+		g_logger(G_LOG_LEVEL_CRITICAL, "Failed to load config file: %s", config_file_name);
 		exit(1);
 	}
 
@@ -830,18 +831,80 @@ int main(int argc, char **argv)
 	int iconf = -1;
 	char buffer[PATH_MAX];
 
+	g_logger(G_LOG_LEVEL_DEBUG, "Parsing renderd config section(s)");
 	for (int section = 0; section < iniparser_getnsec(ini); section++) {
 		const char *name = iniparser_getsecname(ini, section);
-		g_logger(G_LOG_LEVEL_INFO, "Parsing section %s", name);
+		if (strncmp(name, "renderd", 7) == 0) {
+			/* this is a renderd config section */
+			int render_sec = 0;
 
-		if (strncmp(name, "renderd", 7) && strcmp(name, "mapnik")) {
-			if (config.tile_dir == NULL) {
-				g_logger(G_LOG_LEVEL_CRITICAL, "No valid (active) renderd config section available");
+			if (sscanf(name, "renderd%i", &render_sec) != 1) {
+				render_sec = 0;
+			}
+
+			g_logger(G_LOG_LEVEL_DEBUG, "Parsing renderd config section %i: %s", render_sec, name);
+
+			if (render_sec >= MAX_SLAVES) {
+				g_logger(G_LOG_LEVEL_CRITICAL, "Can't handle more than %i renderd config sections",
+					 MAX_SLAVES);
 				exit(7);
 			}
 
-			/* this is a map section */
+			snprintf(buffer, sizeof(buffer), "%s:socketname", name);
+			config_slaves[render_sec].socketname = iniparser_getstring(ini,
+							       buffer, (char *) RENDER_SOCKET);
+			snprintf(buffer, sizeof(buffer), "%s:iphostname", name);
+			config_slaves[render_sec].iphostname = iniparser_getstring(ini,
+							       buffer, "");
+			snprintf(buffer, sizeof(buffer), "%s:ipport", name);
+			config_slaves[render_sec].ipport = iniparser_getint(ini, buffer, 0);
+			snprintf(buffer, sizeof(buffer), "%s:num_threads", name);
+			config_slaves[render_sec].num_threads = iniparser_getint(ini,
+								buffer, NUM_THREADS);
+			snprintf(buffer, sizeof(buffer), "%s:tile_dir", name);
+			config_slaves[render_sec].tile_dir = iniparser_getstring(ini,
+							     buffer, (char *) HASH_PATH);
+			snprintf(buffer, sizeof(buffer), "%s:stats_file", name);
+			config_slaves[render_sec].stats_filename = iniparser_getstring(ini,
+					buffer, NULL);
+			snprintf(buffer, sizeof(buffer), "%s:pid_file", name);
+			config_slaves[render_sec].pid_filename = iniparser_getstring(ini,
+					buffer, (char *) PIDFILE);
+
+			if (render_sec == active_slave) {
+				config.socketname = config_slaves[render_sec].socketname;
+				config.iphostname = config_slaves[render_sec].iphostname;
+				config.ipport = config_slaves[render_sec].ipport;
+				config.num_threads = config_slaves[render_sec].num_threads;
+				config.tile_dir = config_slaves[render_sec].tile_dir;
+				config.stats_filename
+					= config_slaves[render_sec].stats_filename;
+				config.pid_filename
+					= config_slaves[render_sec].pid_filename;
+				config.mapnik_plugins_dir = iniparser_getstring(ini,
+							    "mapnik:plugins_dir", (char *) MAPNIK_PLUGINS);
+				config.mapnik_font_dir = iniparser_getstring(ini,
+							 "mapnik:font_dir", (char *) FONT_DIR);
+				config.mapnik_font_dir_recurse = iniparser_getboolean(ini,
+								 "mapnik:font_dir_recurse", FONT_RECURSE);
+			} else {
+				noSlaveRenders += config_slaves[render_sec].num_threads;
+			}
+		}
+	}
+
+	g_logger(G_LOG_LEVEL_DEBUG, "Parsing map config section(s)");
+	for (int section = 0; section < iniparser_getnsec(ini); section++) {
+		const char *name = iniparser_getsecname(ini, section);
+		if (strncmp(name, "renderd", 7) && strcmp(name, "mapnik")) {
+			/* this is a map config section */
+			if (config.num_threads == NULL || config.tile_dir == NULL) {
+				g_logger(G_LOG_LEVEL_CRITICAL, "No valid (active) renderd config section available");
+				exit(7);
+			}
 			iconf++;
+
+			g_logger(G_LOG_LEVEL_DEBUG, "Parsing map config section %i: %s", iconf, name);
 
 			if (iconf >= XMLCONFIGS_MAX) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "Config: more than %d configurations found", XMLCONFIGS_MAX);
@@ -960,62 +1023,6 @@ int main(int argc, char **argv)
 			 * as it is needed to configure mapniks number of connections
 			 */
 			maps[iconf].num_threads = config.num_threads;
-
-		} else if (strncmp(name, "renderd", 7) == 0) {
-			int render_sec = 0;
-
-			if (sscanf(name, "renderd%i", &render_sec) != 1) {
-				render_sec = 0;
-			}
-
-			g_logger(G_LOG_LEVEL_INFO, "Parsing render section %i", render_sec);
-
-			if (render_sec >= MAX_SLAVES) {
-				g_logger(G_LOG_LEVEL_CRITICAL, "Can't handle more than %i render sections",
-					 MAX_SLAVES);
-				exit(7);
-			}
-
-			snprintf(buffer, sizeof(buffer), "%s:socketname", name);
-			config_slaves[render_sec].socketname = iniparser_getstring(ini,
-							       buffer, (char *) RENDER_SOCKET);
-			snprintf(buffer, sizeof(buffer), "%s:iphostname", name);
-			config_slaves[render_sec].iphostname = iniparser_getstring(ini,
-							       buffer, "");
-			snprintf(buffer, sizeof(buffer), "%s:ipport", name);
-			config_slaves[render_sec].ipport = iniparser_getint(ini, buffer, 0);
-			snprintf(buffer, sizeof(buffer), "%s:num_threads", name);
-			config_slaves[render_sec].num_threads = iniparser_getint(ini,
-								buffer, NUM_THREADS);
-			snprintf(buffer, sizeof(buffer), "%s:tile_dir", name);
-			config_slaves[render_sec].tile_dir = iniparser_getstring(ini,
-							     buffer, (char *) HASH_PATH);
-			snprintf(buffer, sizeof(buffer), "%s:stats_file", name);
-			config_slaves[render_sec].stats_filename = iniparser_getstring(ini,
-					buffer, NULL);
-			snprintf(buffer, sizeof(buffer), "%s:pid_file", name);
-			config_slaves[render_sec].pid_filename = iniparser_getstring(ini,
-					buffer, (char *) PIDFILE);
-
-			if (render_sec == active_slave) {
-				config.socketname = config_slaves[render_sec].socketname;
-				config.iphostname = config_slaves[render_sec].iphostname;
-				config.ipport = config_slaves[render_sec].ipport;
-				config.num_threads = config_slaves[render_sec].num_threads;
-				config.tile_dir = config_slaves[render_sec].tile_dir;
-				config.stats_filename
-					= config_slaves[render_sec].stats_filename;
-				config.pid_filename
-					= config_slaves[render_sec].pid_filename;
-				config.mapnik_plugins_dir = iniparser_getstring(ini,
-							    "mapnik:plugins_dir", (char *) MAPNIK_PLUGINS);
-				config.mapnik_font_dir = iniparser_getstring(ini,
-							 "mapnik:font_dir", (char *) FONT_DIR);
-				config.mapnik_font_dir_recurse = iniparser_getboolean(ini,
-								 "mapnik:font_dir_recurse", FONT_RECURSE);
-			} else {
-				noSlaveRenders += config_slaves[render_sec].num_threads;
-			}
 		}
 	}
 

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -832,8 +832,10 @@ int main(int argc, char **argv)
 	char buffer[PATH_MAX];
 
 	g_logger(G_LOG_LEVEL_DEBUG, "Parsing renderd config section(s)");
+
 	for (int section = 0; section < iniparser_getnsec(ini); section++) {
 		const char *name = iniparser_getsecname(ini, section);
+
 		if (strncmp(name, "renderd", 7) == 0) {
 			/* this is a renderd config section */
 			int render_sec = 0;
@@ -894,14 +896,17 @@ int main(int argc, char **argv)
 	}
 
 	g_logger(G_LOG_LEVEL_DEBUG, "Parsing map config section(s)");
+
 	for (int section = 0; section < iniparser_getnsec(ini); section++) {
 		const char *name = iniparser_getsecname(ini, section);
+
 		if (strncmp(name, "renderd", 7) && strcmp(name, "mapnik")) {
 			/* this is a map config section */
 			if (config.num_threads == NULL || config.tile_dir == NULL) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "No valid (active) renderd config section available");
 				exit(7);
 			}
+
 			iconf++;
 
 			g_logger(G_LOG_LEVEL_DEBUG, "Parsing map config section %i: %s", iconf, name);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,8 +103,10 @@ add_test(
 add_test(
   NAME start_renderd
   COMMAND ${BASH} -c "
-    echo '${PROJECT_BINARY_DIR}/src/renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --foreground > ${PROJECT_BINARY_DIR}/tests/logs/renderd.log 2>&1 &' > ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
+    echo '${PROJECT_BINARY_DIR}/src/renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --foreground --slave 0 > ${PROJECT_BINARY_DIR}/tests/logs/renderd.log 2>&1 &' > ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
     echo 'printf \${!} > ${PROJECT_BINARY_DIR}/tests/run/renderd.pid' >> ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
+    echo '${PROJECT_BINARY_DIR}/src/renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --foreground --slave 1 > ${PROJECT_BINARY_DIR}/tests/logs/renderd1.log 2>&1 &' >> ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
+    echo 'printf \${!} > ${PROJECT_BINARY_DIR}/tests/run/renderd1.pid' >> ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
     echo 'exit 0' >> ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
     ${BASH} ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
   "
@@ -156,6 +158,7 @@ add_test(
   NAME stop_renderd
   COMMAND ${BASH} -c "
     ${KILL_EXECUTABLE} $(${CAT_EXECUTABLE} run/renderd.pid) && ${RM} run/renderd.pid
+    ${KILL_EXECUTABLE} $(${CAT_EXECUTABLE} run/renderd1.pid) && ${RM} run/renderd1.pid
   "
 )
 add_test(

--- a/tests/httpd.conf.in
+++ b/tests/httpd.conf.in
@@ -36,10 +36,33 @@ Redirect /renderd-example-map/leaflet/leaflet.min.js https://unpkg.com/leaflet/d
   ModTileTileDir @PROJECT_BINARY_DIR@/tests/tiles
 </VirtualHost>
 
+<VirtualHost *:8181>
+  LoadTileConfigFile @PROJECT_BINARY_DIR@/tests/conf/renderd.conf
+  ModTileBulkMode Off
+  ModTileCacheDurationDirty 900
+  ModTileCacheDurationLowZoom 9 518400
+  ModTileCacheDurationMax 604800
+  ModTileCacheDurationMediumZoom 13 86400
+  ModTileCacheDurationMinimum 10800
+  ModTileCacheLastModifiedFactor 0.20
+  ModTileEnableStats On
+  ModTileEnableTileThrottling Off
+  ModTileEnableTileThrottlingXForward 0
+  ModTileMaxLoadMissing 5
+  ModTileMaxLoadOld 2
+  ModTileMissingRequestTimeout 10
+  ModTileRenderdSocketAddr 127.0.0.1 8881
+  ModTileRequestTimeout 3
+  ModTileThrottlingRenders 128 0.2
+  ModTileThrottlingTiles 10000 1
+  ModTileTileDir @PROJECT_BINARY_DIR@/tests/tiles
+</VirtualHost>
+
 CustomLog logs/access_log "%h %l %u %t \"%r\" %>s %b"
 ErrorLog logs/error_log
 Group @NOGROUP_NAME@
 Listen 8081
+Listen 8181
 LogLevel debug
 PidFile run/httpd.pid
 ServerName localhost

--- a/tests/renderd.conf.in
+++ b/tests/renderd.conf.in
@@ -1,9 +1,3 @@
-[renderd]
-pid_file=@PROJECT_BINARY_DIR@/tests/run/renderd.pid
-socketname=@PROJECT_BINARY_DIR@/tests/run/renderd.sock
-stats_file=@PROJECT_BINARY_DIR@/tests/run/renderd.stats
-tile_dir=@PROJECT_BINARY_DIR@/tests/tiles
-
 [mapnik]
 font_dir_recurse=true
 font_dir=@MAPNIK_FONTS_DIR@
@@ -13,3 +7,16 @@ plugins_dir=@MAPNIK_PLUGINS_DIR@
 TILEDIR=@PROJECT_BINARY_DIR@/tests/tiles
 URI=/tiles/renderd-example
 XML=@PROJECT_BINARY_DIR@/tests/www/mapnik.xml
+
+[renderd1]
+iphostname=127.0.0.1
+ipport=8881
+pid_file=@PROJECT_BINARY_DIR@/tests/run/renderd1.pid
+stats_file=@PROJECT_BINARY_DIR@/tests/run/renderd1.stats
+tile_dir=@PROJECT_BINARY_DIR@/tests/tiles
+
+[renderd]
+pid_file=@PROJECT_BINARY_DIR@/tests/run/renderd.pid
+socketname=@PROJECT_BINARY_DIR@/tests/run/renderd.sock
+stats_file=@PROJECT_BINARY_DIR@/tests/run/renderd.stats
+tile_dir=@PROJECT_BINARY_DIR@/tests/tiles


### PR DESCRIPTION
Currently `renderd*` sections must be read in first in order to populate the `num_threads` & `tile_dir` values for each `map` section.
https://github.com/openstreetmap/mod_tile/blob/d8a0f29cfe0b8ae15db4e3d3ccf3981366e3bcbf/src/daemon.c#L838-L841

This change will allow `renderd*` sections to be anywhere within the `renderd` config file by first reading the prerequisite `renderd*` section(s) and then reading any `map` section(s).