### PR TITLE
Added option to `renderd` to write logs to file while running as daemon

### DIFF
--- a/docs/man/renderd.1
+++ b/docs/man/renderd.1
@@ -1,4 +1,4 @@
-.TH RENDERD 1 "May 21, 2022"
+.TH RENDERD 1 "March 8, 2023"
 .\" Please adjust this date whenever revising the manpage.
 .SH NAME
 renderd \- Rendering daemon for rendering OpenStreetMap tiles.
@@ -15,19 +15,27 @@ command.
 is a rendering daemon for map tiles with the mapnik library. It receives render requests
 on a socket. Renderd queues requests in a number of different queues to manage load while 
 rendering the requests with the mapnik library. By default renderd will start as a daemon.
-It will log information in the syslog.
+It will write logs to systemd journal or syslog.
 .PP
 .SH OPTIONS
 This programs follow the usual GNU command line syntax, with long
 options starting with two dashes (`-').
 A summary of options is included below.
 .TP
-\fB\-f\fR|\-\-foreground
-Run renderd in the foreground for debugging purposes.
-.TP
 \fB\-c\fR|\-\-config
 Set the location of the config file used to configure the various parameters of renderd,
 like the mapnik style sheet. The default is /etc/renderd.conf
+.TP
+\fB\-f\fR|\-\-foreground
+Run renderd in the foreground. Logs will be written to stderr/stdout rather than to systemd journal or syslog.
+.br
+This option and \fB\-l\fR|\-\-logpath are mutually exclusive.
+.TP
+\fB\-l\fR|\-\-logpath
+Set the location of a directory to which logs will be written to rather than to systemd journal or syslog. The files will be
+named "renderd.stdout.log" and "renderd.stderr.log".
+.br
+This option and \fB\-f\fR|\-\-foreground are mutually exclusive.
 .TP
 \fB\-s\fR|\-\-slave
 Renderd can be used in a distributed fashion across multiple rendering servers. The master renderd handles queuing and

--- a/src/g_logger.c
+++ b/src/g_logger.c
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <syslog.h>
 
-extern int foreground;
+extern int log_to_std_streams;
 
 const char *g_logger_level_name(int log_level)
 {
@@ -75,7 +75,7 @@ void g_logger(int log_level, const char *format, ...)
 
 	const GLogField log_fields_prefixed[] = {{"MESSAGE", log_message_prefixed, -1}};
 
-	if (foreground == 1) {
+	if (log_to_std_streams == 1) {
 		switch (log_level) {
 			// Levels >= G_LOG_LEVEL_ERROR will terminate the program
 			case G_LOG_LEVEL_ERROR:

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -90,7 +90,7 @@ using namespace mapnik;
 #define RENDER_SIZE (512)
 #endif
 
-extern int foreground;
+extern int log_to_std_streams;
 
 struct projectionconfig {
 	double bound_x0;

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -99,7 +99,7 @@ char *mutexfilename;
 int layerCount = 0;
 int global_max_zoom = 0;
 
-int foreground = 0;
+int log_to_std_streams = 0;
 
 struct storage_backends {
 	struct storage_backend ** stores;

--- a/src/render_expired.c
+++ b/src/render_expired.c
@@ -74,7 +74,7 @@ static int maxZoom = 18;
 static int verbose = 0;
 static int maxLoad = MAX_LOAD_OLD;
 
-int foreground = 1;
+int log_to_std_streams = 1;
 
 void display_rate(struct timeval start, struct timeval end, int num)
 {

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -58,7 +58,7 @@ static int maxZoom = MAX_ZOOM;
 static int verbose = 0;
 static int maxLoad = MAX_LOAD_OLD;
 
-int foreground = 1;
+int log_to_std_streams = 1;
 
 
 void display_rate(struct timeval start, struct timeval end, int num)

--- a/src/render_old.c
+++ b/src/render_old.c
@@ -64,7 +64,7 @@ static int max_load = MAX_LOAD_OLD;
 static time_t planetTime;
 static struct timeval start, end;
 
-int foreground = 1;
+int log_to_std_streams = 1;
 
 
 

--- a/src/speedtest.cpp
+++ b/src/speedtest.cpp
@@ -71,7 +71,7 @@ static double boundx1 = 3.2;
 static double boundy1 = 58.8;
 #endif
 
-int foreground = 1;
+int log_to_std_streams = 1;
 
 
 static double minmax(double a, double b, double c)

--- a/src/store.c
+++ b/src/store.c
@@ -24,7 +24,7 @@
 #include "store_null.h"
 #include "g_logger.h"
 
-extern int foreground;
+extern int log_to_std_streams;
 
 /**
  * In Apache 2.2, we call the init_storage_backend once per process. For mpm_worker and mpm_event multiple threads therefore use the same

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,15 +101,12 @@ add_test(
   COMMAND ${MKDIR_EXECUTABLE} -p -v logs run tiles
 )
 add_test(
-  NAME start_renderd
-  COMMAND ${BASH} -c "
-    echo '${PROJECT_BINARY_DIR}/src/renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --foreground --slave 0 > ${PROJECT_BINARY_DIR}/tests/logs/renderd.log 2>&1 &' > ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
-    echo 'printf \${!} > ${PROJECT_BINARY_DIR}/tests/run/renderd.pid' >> ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
-    echo '${PROJECT_BINARY_DIR}/src/renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --foreground --slave 1 > ${PROJECT_BINARY_DIR}/tests/logs/renderd1.log 2>&1 &' >> ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
-    echo 'printf \${!} > ${PROJECT_BINARY_DIR}/tests/run/renderd1.pid' >> ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
-    echo 'exit 0' >> ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
-    ${BASH} ${PROJECT_BINARY_DIR}/tests/renderd_start.sh
-  "
+  NAME start_renderd_slave_0
+  COMMAND renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --logpath ${PROJECT_BINARY_DIR}/tests/logs --slave 0
+)
+add_test(
+  NAME start_renderd_slave_1
+  COMMAND renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --logpath ${PROJECT_BINARY_DIR}/tests/logs --slave 1
 )
 add_test(
   NAME start_httpd
@@ -155,9 +152,14 @@ add_test(
   COMMAND ${RM} -v tile.png
 )
 add_test(
-  NAME stop_renderd
+  NAME stop_renderd_slave_0
   COMMAND ${BASH} -c "
     ${KILL_EXECUTABLE} $(${CAT_EXECUTABLE} run/renderd.pid) && ${RM} run/renderd.pid
+  "
+)
+add_test(
+  NAME stop_renderd_slave_1
+  COMMAND ${BASH} -c "
     ${KILL_EXECUTABLE} $(${CAT_EXECUTABLE} run/renderd1.pid) && ${RM} run/renderd1.pid
   "
 )
@@ -178,24 +180,34 @@ add_test(
 set_tests_properties(create_dirs PROPERTIES
   FIXTURES_SETUP httpd_started
 )
-set_tests_properties(start_renderd PROPERTIES
+set_tests_properties(start_renderd_slave_0 PROPERTIES
   DEPENDS create_dirs
+  ENVIRONMENT "G_MESSAGES_DEBUG=all"
+  FIXTURES_SETUP httpd_started
+)
+set_tests_properties(start_renderd_slave_1 PROPERTIES
+  DEPENDS create_dirs
+  ENVIRONMENT "G_MESSAGES_DEBUG=all"
   FIXTURES_SETUP httpd_started
 )
 set_tests_properties(start_httpd PROPERTIES
   DEPENDS create_dirs
   FIXTURES_SETUP httpd_started
 )
-set_tests_properties(stop_renderd PROPERTIES
+set_tests_properties(stop_renderd_slave_0 PROPERTIES
   FIXTURES_CLEANUP httpd_started
   REQUIRED_FILES run/renderd.pid
+)
+set_tests_properties(stop_renderd_slave_1 PROPERTIES
+  FIXTURES_CLEANUP httpd_started
+  REQUIRED_FILES run/renderd1.pid
 )
 set_tests_properties(stop_httpd PROPERTIES
   FIXTURES_CLEANUP httpd_started
   REQUIRED_FILES run/httpd.pid
 )
 set_tests_properties(clear_dirs PROPERTIES
-  DEPENDS "stop_renderd;stop_httpd"
+  DEPENDS "stop_renderd_slave_0;stop_renderd_slave_1;stop_httpd"
   FIXTURES_CLEANUP httpd_started
   REQUIRED_FILES "logs;run;tiles"
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,15 +98,15 @@ add_test(
 )
 add_test(
   NAME create_dirs
-  COMMAND ${MKDIR_EXECUTABLE} -p -v logs run tiles
+  COMMAND ${MKDIR_EXECUTABLE} -p -v logs/slave_0 logs/slave_1 run tiles
 )
 add_test(
   NAME start_renderd_slave_0
-  COMMAND renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --logpath ${PROJECT_BINARY_DIR}/tests/logs --slave 0
+  COMMAND renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --logpath ${PROJECT_BINARY_DIR}/tests/logs/slave_0 --slave 0
 )
 add_test(
   NAME start_renderd_slave_1
-  COMMAND renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --logpath ${PROJECT_BINARY_DIR}/tests/logs --slave 1
+  COMMAND renderd --config ${PROJECT_BINARY_DIR}/tests/conf/renderd.conf --logpath ${PROJECT_BINARY_DIR}/tests/logs/slave_1 --slave 1
 )
 add_test(
   NAME start_httpd


### PR DESCRIPTION
This will help with testing and debugging by allowing `renderd` to run in the background during tests while still easily having logs available for examination.

Also enabled `renderd` debug log output while running tests and updated man file.