### PR TITLE
Generate config files and directories with CMake

### DIFF
--- a/.github/actions/cmake/install/action.yml
+++ b/.github/actions/cmake/install/action.yml
@@ -3,5 +3,5 @@ runs:
   using: composite
   steps:
     - name: Install `mod_tile`
-      run: cmake --install build
+      run: ${{ !matrix.image && 'sudo' || '' }} cmake --install build
       shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/cmake/test/action.yml
+++ b/.github/actions/cmake/test/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Archive test artifacts on failure
       if: failure()
       run: |
-        TAR_FILENAME=${{ matrix.image }}-${{ matrix.compiler }}.tar.gz
+        TAR_FILENAME=${{ matrix.image || matrix.os }}-${{ matrix.compiler }}.tar.gz
         TAR_FILENAME=$(echo "${TAR_FILENAME}" | sed 's/:/-/g')
         tar -zcf /tmp/${TAR_FILENAME} tests
       shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,12 +90,12 @@ jobs:
       CFLAGS: -Wno-implicit-function-declaration
       LDFLAGS: -undefined dynamic_lookup
       LIBRARY_PATH: /usr/local/lib
-    name: ${{ matrix.image }} (${{ matrix.build_system }}) (${{ matrix.compiler }})
-    runs-on: ${{ matrix.image }}
+    name: ${{ matrix.os }} (${{ matrix.build_system }}) (${{ matrix.compiler }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        image:
+        os:
           - macos-11
           - macos-12
         build_system:
@@ -105,10 +105,10 @@ jobs:
         on_default_branch:
           - ${{ contains(github.ref, 'master') || contains(github.ref, 'develop') }}
         include:
-          - image: macos-13
+          - os: macos-13
             build_system: Autotools
             compiler: LLVM
-          - image: macos-13
+          - os: macos-13
             build_system: CMake
             compiler: LLVM
         exclude:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 #-----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 #-----------------------------------------------------------------------------
@@ -101,13 +101,33 @@ check_include_file(sys/loadavg.h HAVE_SYS_LOADAVG_H)
 #
 #-----------------------------------------------------------------------------
 
-execute_process(COMMAND ${APXS_EXECUTABLE} -q exp_libexecdir
-  OUTPUT_VARIABLE HTTPD_MODULES_DIR
+execute_process(COMMAND ${APXS_EXECUTABLE} -q libexecdir
+  OUTPUT_VARIABLE HTTPD_LIBEXECDIR
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
+execute_process(COMMAND ${APXS_EXECUTABLE} -q sysconfdir
+  OUTPUT_VARIABLE HTTPD_SYSCONFDIR
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if(LibMapnik_VERSION STRLESS "4")
+  find_program(MAPNIK_CONFIG_EXECUTABLE NAMES mapnik-config REQUIRED)
+  execute_process(COMMAND ${MAPNIK_CONFIG_EXECUTABLE} --fonts
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE MAPNIK_FONTS_DIR
+  )
+  execute_process(COMMAND ${MAPNIK_CONFIG_EXECUTABLE} --input-plugins
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE MAPNIK_PLUGINS_DIR
+  )
+elseif(LibMapnik_VERSION STRGREATER_EQUAL "4")
+  pkg_get_variable(MAPNIK_FONTS_DIR libmapnik fonts_dir)
+  pkg_get_variable(MAPNIK_PLUGINS_DIR libmapnik plugins_dir)
+endif()
+
 if(NOT CMAKE_INSTALL_MODULESDIR)
-  set(CMAKE_INSTALL_MODULESDIR ${HTTPD_MODULES_DIR})
+  set(CMAKE_INSTALL_MODULESDIR ${HTTPD_LIBEXECDIR})
 endif()
 
 if(Cairo_FOUND)
@@ -130,17 +150,42 @@ if(CMAKE_HAVE_PTHREAD_H)
   set(HAVE_PTHREAD 1)
 endif()
 
-set(VERSION ${PROJECT_VERSION})
+set(MAPNIK_FONTS_DIR "${MAPNIK_FONTS_DIR}")
+set(MAPNIK_FONTS_DIR_RECURSE 0)
+set(MAPNIK_PLUGINS_DIR "${MAPNIK_PLUGINS_DIR}")
+set(RENDERD_CONFIG "/${CMAKE_INSTALL_SYSCONFDIR}/renderd.conf")
+set(RENDERD_RUN_DIR "/${CMAKE_INSTALL_RUNSTATEDIR}/renderd")
+set(RENDERD_TILE_DIR "/${CMAKE_INSTALL_LOCALSTATEDIR}/cache/renderd/tiles")
+
+set(RENDERD_PIDFILE "${RENDERD_RUN_DIR}/renderd.pid")
+set(RENDERD_SOCKET "${RENDERD_RUN_DIR}/renderd.sock")
+
+set(TILE_LOAD_DIRECTORY "${HTTPD_SYSCONFDIR}")
+set(TILE_LOAD_FILENAME "tile.load")
+set(VERSION "${PROJECT_VERSION}")
 
 #-----------------------------------------------------------------------------
 #
-#  config.h
+#  Configure
 #
 #-----------------------------------------------------------------------------
 
+# include/config.h.in
 configure_file(
   ${PROJECT_SOURCE_DIR}/includes/config.h.in
   ${PROJECT_SOURCE_DIR}/includes/config.h
+)
+
+# etc/apache2/tile.load.in
+configure_file(
+  ${PROJECT_SOURCE_DIR}/etc/apache2/tile.load.in
+  ${PROJECT_BINARY_DIR}/tile.load
+)
+
+# etc/renderd/renderd.conf.in
+configure_file(
+  ${PROJECT_SOURCE_DIR}/etc/renderd/renderd.conf.in
+  ${PROJECT_BINARY_DIR}/renderd.conf
 )
 
 #-----------------------------------------------------------------------------
@@ -157,6 +202,57 @@ add_subdirectory(src)
 #
 #-----------------------------------------------------------------------------
 
+# Determine install destination for 'etc/apache2/tile.load.in'
+if(EXISTS "/etc/os-release")
+  execute_process(COMMAND sh -c ". /etc/os-release && echo $ID"
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    OUTPUT_VARIABLE DISTRO_ID
+  )
+  message(STATUS "Found ID='${DISTRO_ID}' in '/etc/os-release'")
+  if(DISTRO_ID MATCHES "arch")
+    set(TILE_LOAD_DIRECTORY "${HTTPD_SYSCONFDIR}/extra")
+    set(TILE_LOAD_FILENAME "httpd-tile.conf")
+  elseif(DISTRO_ID MATCHES "centos|fedora|rhel")
+    set(TILE_LOAD_DIRECTORY "${HTTPD_SYSCONFDIR}.modules.d")
+    set(TILE_LOAD_FILENAME "11-tile.conf")
+  elseif(DISTRO_ID MATCHES "debian|ubuntu")
+    set(TILE_LOAD_DIRECTORY "${HTTPD_SYSCONFDIR}/mods-available")
+  elseif(DISTRO_ID MATCHES "freebsd")
+    set(TILE_LOAD_DIRECTORY "${HTTPD_SYSCONFDIR}/modules.d")
+    set(TILE_LOAD_FILENAME "080_tile.conf")
+  endif()
+elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  set(TILE_LOAD_DIRECTORY "${HTTPD_SYSCONFDIR}/extra")
+  set(TILE_LOAD_FILENAME "httpd-tile.conf")
+endif()
+message(STATUS "File 'etc/apache2/tile.load.in' will be installed to '${TILE_LOAD_DIRECTORY}/${TILE_LOAD_FILENAME}'")
+
+# Directories
+install(
+  DIRECTORY
+  DESTINATION ${RENDERD_TILE_DIR}
+)
+
+install(
+  DIRECTORY
+  DESTINATION ${RENDERD_RUN_DIR}
+)
+
+# Configuration files
+install(
+  FILES
+    ${PROJECT_BINARY_DIR}/tile.load
+  DESTINATION ${TILE_LOAD_DIRECTORY}
+  RENAME ${TILE_LOAD_FILENAME}
+)
+
+install(
+  FILES
+    ${PROJECT_BINARY_DIR}/renderd.conf
+  DESTINATION /${CMAKE_INSTALL_SYSCONFDIR}
+)
+
+# Targets
 install(
   TARGETS
     mod_tile
@@ -169,6 +265,7 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
+# Man files
 if (ENABLE_MAN)
 install(
   FILES

--- a/etc/apache2/tile.load.in
+++ b/etc/apache2/tile.load.in
@@ -1,0 +1,1 @@
+LoadModule tile_module @CMAKE_INSTALL_MODULESDIR@/mod_tile.so

--- a/etc/renderd/renderd.conf.in
+++ b/etc/renderd/renderd.conf.in
@@ -1,0 +1,10 @@
+[renderd]
+pid_file=@RENDERD_PIDFILE@
+socketname=@RENDERD_SOCKET@
+stats_file=@RENDERD_RUN_DIR@/renderd.stats
+tile_dir=@RENDERD_TILE_DIR@
+
+[mapnik]
+font_dir=@MAPNIK_FONTS_DIR@
+font_dir_recurse=@MAPNIK_FONTS_DIR_RECURSE@
+plugins_dir=@MAPNIK_PLUGINS_DIR@

--- a/includes/config.h.in
+++ b/includes/config.h.in
@@ -14,5 +14,14 @@
 #cmakedefine HAVE_LIBMEMCACHED @HAVE_LIBMEMCACHED@
 #cmakedefine HAVE_LIBRADOS @HAVE_LIBRADOS@
 
+/* Define configuration options. */
+#cmakedefine MAPNIK_FONTS_DIR "@MAPNIK_FONTS_DIR@"
+#cmakedefine MAPNIK_FONTS_DIR_RECURSE "@MAPNIK_FONTS_DIR_RECURSE@"
+#cmakedefine MAPNIK_PLUGINS_DIR "@MAPNIK_PLUGINS_DIR@"
+#cmakedefine RENDERD_CONFIG "@RENDERD_CONFIG@"
+#cmakedefine RENDERD_PIDFILE "@RENDERD_PIDFILE@"
+#cmakedefine RENDERD_SOCKET "@RENDERD_SOCKET@"
+#cmakedefine RENDERD_TILE_DIR "@RENDERD_TILE_DIR@"
+
 /* Version number of project */
 #cmakedefine VERSION "@VERSION@"

--- a/includes/protocol.h
+++ b/includes/protocol.h
@@ -18,6 +18,8 @@
 #ifndef PROTOCOL_H
 #define PROTOCOL_H
 
+#include "config.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -34,9 +36,15 @@ extern "C" {
  */
 #define TILE_PATH_MAX (256)
 #define PROTO_VER (3)
-#define RENDER_SOCKET "/run/renderd/renderd.sock"
-#define RENDER_HOST "localhost"
-#define RENDER_PORT 7654
+#ifndef RENDERD_SOCKET
+#define RENDERD_SOCKET "/run/renderd/renderd.sock"
+#endif
+#ifndef RENDERD_HOST
+#define RENDERD_HOST "localhost"
+#endif
+#ifndef RENDERD_PORT
+#define RENDERD_PORT 7654
+#endif
 #define XMLCONFIG_MAX 41
 
 enum protoCmd { cmdIgnore, cmdRender, cmdDirty, cmdDone, cmdNotDone, cmdRenderPrio, cmdRenderBulk, cmdRenderLow };

--- a/includes/render_config.h
+++ b/includes/render_config.h
@@ -18,6 +18,8 @@
 #ifndef RENDER_CONFIG_H
 #define RENDER_CONFIG_H
 
+#include "config.h"
+
 #define MAX_ZOOM 20
 
 // MAX_SIZE is the biggest file which we will return to the user
@@ -25,7 +27,9 @@
 
 // With directory hashing enabled we rewrite the path so that tiles are really stored here instead
 #define DIRECTORY_HASH
-#define HASH_PATH "/var/cache/renderd/tiles"
+#ifndef RENDERD_TILE_DIR
+#define RENDERD_TILE_DIR "/var/cache/renderd/tiles"
+#endif
 
 // TILE_PATH is where Openlayers with try to fetch the "z/x/y.png" tiles from
 // this is now only used if DIRECTORY_HASH is undefined
@@ -45,20 +49,34 @@
 #define VERYOLD_THRESHOLD 31536000000000
 
 // Location of osm.xml file
+#ifndef RENDERD_CONFIG
 #define RENDERD_CONFIG "/etc/renderd.conf"
+#endif
 // The XML configuration used if one is not provided
+#ifndef XMLCONFIG_DEFAULT
 #define XMLCONFIG_DEFAULT "default"
+#endif
 // Maximum number of configurations that mod tile will allow
+#ifndef XMLCONFIGS_MAX
 #define XMLCONFIGS_MAX 10
+#endif
 // Default PID file path
-#define PIDFILE "/run/renderd/renderd.pid"
+#ifndef RENDERD_PIDFILE
+#define RENDERD_PIDFILE "/run/renderd/renderd.pid"
+#endif
 
 // Mapnik input plugins (will need to adjust for 32 bit libs)
-#define MAPNIK_PLUGINS "/usr/local/lib64/mapnik/input"
+#ifndef MAPNIK_PLUGINS_DIR
+#define MAPNIK_PLUGINS_DIR "/usr/local/lib64/mapnik/input"
+#endif
 
 // Default directory to search for fonts. Recursion can be enabled if desired.
-#define FONT_DIR "/usr/local/lib64/mapnik/fonts"
-#define FONT_RECURSE 0
+#ifndef MAPNIK_FONTS_DIR
+#define MAPNIK_FONTS_DIR "/usr/local/lib64/mapnik/fonts"
+#endif
+#ifndef MAPNIK_FONTS_DIR_RECURSE
+#define MAPNIK_FONTS_DIR_RECURSE 0
+#endif
 
 // Typical interval between planet imports, used as basis for tile expiry times
 #define PLANET_INTERVAL (7 * 24 * 60 * 60)

--- a/src/convert_meta.c
+++ b/src/convert_meta.c
@@ -40,7 +40,7 @@
 #include "dir_utils.h"
 #include "store.h"
 
-char *tile_dir = HASH_PATH;
+char *tile_dir = RENDERD_TILE_DIR;
 
 #ifndef METATILE
 #warning("convert_meta not implemented for non-metatile mode. Feel free to submit fix")
@@ -188,7 +188,7 @@ int main(int argc, char **argv)
 				fprintf(stderr, "Usage: convert_meta [OPTION] ...\n");
 				fprintf(stderr, "Convert the rendered PNGs into the more efficient .meta format\n");
 				fprintf(stderr, "  -m, --map       convert tiles in this map (default is 'default')\n");
-				fprintf(stderr, "  -t, --tile-dir  tile cache directory (default is '" HASH_PATH "')\n");
+				fprintf(stderr, "  -t, --tile-dir  tile cache directory (default is '" RENDERD_TILE_DIR "')\n");
 				fprintf(stderr, "  -u, --unpack    unpack the .meta files back to PNGs\n");
 				fprintf(stderr, "  -z, --min-zoom  only process tiles greater or equal to this zoom level (default is 0)\n");
 				fprintf(stderr, "  -Z, --max-zoom  only process tiles less than or equal to this zoom level (default is %d)\n", MAX_ZOOM);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -854,7 +854,7 @@ int main(int argc, char **argv)
 
 			snprintf(buffer, sizeof(buffer), "%s:socketname", name);
 			config_slaves[render_sec].socketname = iniparser_getstring(ini,
-							       buffer, (char *) RENDER_SOCKET);
+							       buffer, (char *) RENDERD_SOCKET);
 			snprintf(buffer, sizeof(buffer), "%s:iphostname", name);
 			config_slaves[render_sec].iphostname = iniparser_getstring(ini,
 							       buffer, "");
@@ -865,13 +865,13 @@ int main(int argc, char **argv)
 								buffer, NUM_THREADS);
 			snprintf(buffer, sizeof(buffer), "%s:tile_dir", name);
 			config_slaves[render_sec].tile_dir = iniparser_getstring(ini,
-							     buffer, (char *) HASH_PATH);
+							     buffer, (char *) RENDERD_TILE_DIR);
 			snprintf(buffer, sizeof(buffer), "%s:stats_file", name);
 			config_slaves[render_sec].stats_filename = iniparser_getstring(ini,
 					buffer, NULL);
 			snprintf(buffer, sizeof(buffer), "%s:pid_file", name);
 			config_slaves[render_sec].pid_filename = iniparser_getstring(ini,
-					buffer, (char *) PIDFILE);
+					buffer, (char *) RENDERD_PIDFILE);
 
 			if (render_sec == active_slave) {
 				config.socketname = config_slaves[render_sec].socketname;
@@ -884,11 +884,11 @@ int main(int argc, char **argv)
 				config.pid_filename
 					= config_slaves[render_sec].pid_filename;
 				config.mapnik_plugins_dir = iniparser_getstring(ini,
-							    "mapnik:plugins_dir", (char *) MAPNIK_PLUGINS);
+							    "mapnik:plugins_dir", (char *) MAPNIK_PLUGINS_DIR);
 				config.mapnik_font_dir = iniparser_getstring(ini,
-							 "mapnik:font_dir", (char *) FONT_DIR);
+							 "mapnik:font_dir", (char *) MAPNIK_FONTS_DIR);
 				config.mapnik_font_dir_recurse = iniparser_getboolean(ini,
-								 "mapnik:font_dir_recurse", FONT_RECURSE);
+								 "mapnik:font_dir_recurse", MAPNIK_FONTS_DIR_RECURSE);
 			} else {
 				noSlaveRenders += config_slaves[render_sec].num_threads;
 			}
@@ -902,7 +902,7 @@ int main(int argc, char **argv)
 
 		if (strncmp(name, "renderd", 7) && strcmp(name, "mapnik")) {
 			/* this is a map config section */
-			if (config.num_threads == NULL || config.tile_dir == NULL) {
+			if (config.num_threads == 0 || config.tile_dir == NULL) {
 				g_logger(G_LOG_LEVEL_CRITICAL, "No valid (active) renderd config section available");
 				exit(7);
 			}

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -2726,10 +2726,10 @@ static void *create_tile_config(apr_pool_t *p, server_rec *s)
 	scfg->max_load_old = MAX_LOAD_OLD;
 	scfg->max_load_missing = MAX_LOAD_MISSING;
 	scfg->veryold_threshold = VERYOLD_THRESHOLD;
-	strncpy(scfg->renderd_socket_name, RENDER_SOCKET, PATH_MAX - 1);
+	strncpy(scfg->renderd_socket_name, RENDERD_SOCKET, PATH_MAX - 1);
 	scfg->renderd_socket_name[PATH_MAX - 1] = 0;
 	scfg->renderd_socket_port = 0;
-	strncpy(scfg->tile_dir, HASH_PATH, PATH_MAX - 1);
+	strncpy(scfg->tile_dir, RENDERD_TILE_DIR, PATH_MAX - 1);
 	scfg->tile_dir[PATH_MAX - 1] = 0;
 	memset(&(scfg->cache_extended_hostname), 0, PATH_MAX);
 	scfg->cache_extended_duration = 0;

--- a/src/render_expired.c
+++ b/src/render_expired.c
@@ -39,7 +39,7 @@
 #include "store.h"
 #include "render_submit_queue.h"
 
-const char * tile_dir_default = HASH_PATH;
+const char * tile_dir_default = RENDERD_TILE_DIR;
 
 // macros handling our tile marking arrays (these are essentially bit arrays
 // that have one bit for each tile on the repsective zoom level; since we only
@@ -94,7 +94,7 @@ void display_rate(struct timeval start, struct timeval end, int num)
 
 int main(int argc, char **argv)
 {
-	char *spath = strdup(RENDER_SOCKET);
+	char *spath = strdup(RENDERD_SOCKET);
 	const char *mapname_default = XMLCONFIG_DEFAULT;
 	const char *mapname = mapname_default;
 	const char *tile_dir = tile_dir_default;
@@ -224,7 +224,7 @@ int main(int argc, char **argv)
 				fprintf(stderr, "  -m, --map=MAP                     render tiles in this map (defaults to '" XMLCONFIG_DEFAULT "')\n");
 				fprintf(stderr, "  -n, --num-threads=N               the number of parallel request threads (default 1)\n");
 				fprintf(stderr, "  -s, --socket=SOCKET|HOSTNAME:PORT unix domain socket name or hostname and port for contacting renderd\n");
-				fprintf(stderr, "  -t, --tile-dir                    tile cache directory (defaults to '" HASH_PATH "')\n");
+				fprintf(stderr, "  -t, --tile-dir                    tile cache directory (defaults to '" RENDERD_TILE_DIR "')\n");
 				fprintf(stderr, "  -T, --touch-from=ZOOM             when expiring tiles of ZOOM or higher, touch them instead of re-rendering (default is off)\n");
 				fprintf(stderr, "  -Z, --max-zoom=ZOOM               filter input to only render tiles less than or equal to this zoom level (default is %d)\n", 18);
 				fprintf(stderr, "  -z, --min-zoom=ZOOM               filter input to only render tiles greater or equal to this zoom level (default is 0)\n");

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -42,7 +42,7 @@
 #include "sys_utils.h"
 #include "render_submit_queue.h"
 
-const char * tile_dir_default = HASH_PATH;
+const char * tile_dir_default = RENDERD_TILE_DIR;
 
 #ifndef METATILE
 #warning("render_list not implemented for non-metatile mode. Feel free to submit fix")
@@ -77,7 +77,7 @@ void display_rate(struct timeval start, struct timeval end, int num)
 
 int main(int argc, char **argv)
 {
-	char *spath = strdup(RENDER_SOCKET);
+	char *spath = strdup(RENDERD_SOCKET);
 	const char *mapname_default = XMLCONFIG_DEFAULT;
 	const char *mapname = mapname_default;
 	const char *tile_dir = tile_dir_default;
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 				fprintf(stderr, "  -m, --map=MAP                     render tiles in this map (defaults to '" XMLCONFIG_DEFAULT "')\n");
 				fprintf(stderr, "  -n, --num-threads=N               the number of parallel request threads (default 1)\n");
 				fprintf(stderr, "  -s, --socket=SOCKET|HOSTNAME:PORT unix domain socket name or hostname and port for contacting renderd\n");
-				fprintf(stderr, "  -t, --tile-dir                    tile cache directory (defaults to '" HASH_PATH "')\n");
+				fprintf(stderr, "  -t, --tile-dir                    tile cache directory (defaults to '" RENDERD_TILE_DIR "')\n");
 				fprintf(stderr, "  -Z, --max-zoom=ZOOM               filter input to only render tiles less than or equal to this zoom level (default is %d)\n", MAX_ZOOM);
 				fprintf(stderr, "  -z, --min-zoom=ZOOM               filter input to only render tiles greater or equal to this zoom level (default is 0)\n");
 				fprintf(stderr, "\n");

--- a/src/render_old.c
+++ b/src/render_old.c
@@ -44,7 +44,7 @@
 #include "render_submit_queue.h"
 #include "sys_utils.h"
 
-const char * tile_dir_default = HASH_PATH;
+const char * tile_dir_default = RENDERD_TILE_DIR;
 
 #ifndef METATILE
 #warning("render_old not implemented for non-metatile mode. Feel free to submit fix")
@@ -191,7 +191,7 @@ void render_layer(const char *tilepath, const char *name)
 
 int main(int argc, char **argv)
 {
-	char spath[PATH_MAX] = RENDER_SOCKET;
+	char spath[PATH_MAX] = RENDERD_SOCKET;
 	char *config_file = RENDERD_CONFIG;
 	const char *tile_dir = tile_dir_default;
 	char *map = NULL;
@@ -320,7 +320,7 @@ int main(int argc, char **argv)
 				fprintf(stderr, "  -m, --map=STYLE                   Instead of going through all styls of CONFIG, only use a specific map-style\n");
 				fprintf(stderr, "  -n, --num-threads=N               the number of parallel request threads (default 1)\n");
 				fprintf(stderr, "  -s, --socket=SOCKET|HOSTNAME:PORT unix domain socket name or hostname and port for contacting renderd\n");
-				fprintf(stderr, "  -t, --tile-dir                    tile cache directory (defaults to '" HASH_PATH "')\n");
+				fprintf(stderr, "  -t, --tile-dir                    tile cache directory (defaults to '" RENDERD_TILE_DIR "')\n");
 				fprintf(stderr, "  -T, --timestamp=DD/MM/YY          Overwrite the assumed data of the planet import\n");
 				fprintf(stderr, "  -Z, --max-zoom=ZOOM               filter input to only render tiles less than or equal to this zoom level (default is %d)\n", MAX_ZOOM);
 				fprintf(stderr, "  -z, --min-zoom=ZOOM               filter input to only render tiles greater or equal to this zoom level (default is 0)\n");

--- a/src/render_submit_queue.c
+++ b/src/render_submit_queue.c
@@ -254,13 +254,13 @@ int make_connection(const char *spath)
 		// Create a network socket
 		const char *d = strchr(spath, ':');
 		char *hostname;
-		u_int16_t port = RENDER_PORT;
+		u_int16_t port = RENDERD_PORT;
 		char port_s[6];
 		size_t spath_len = strlen(spath);
 		size_t hostname_len = d ? d - spath : spath_len;
 
 		if (!hostname_len) {
-			hostname = strdup(RENDER_HOST);
+			hostname = strdup(RENDERD_HOST);
 		} else {
 			hostname = malloc(hostname_len + sizeof('\0'));
 			assert(hostname != NULL);
@@ -271,7 +271,7 @@ int make_connection(const char *spath)
 			port = atoi(d + 1);
 
 			if (!port) {
-				port = RENDER_PORT;
+				port = RENDERD_PORT;
 			}
 		}
 

--- a/src/speedtest.cpp
+++ b/src/speedtest.cpp
@@ -186,7 +186,7 @@ int process_loop(int fd, int x, int y, int z, const char * map)
 
 int main(int argc, char **argv)
 {
-	const char *spath = RENDER_SOCKET;
+	const char *spath = RENDERD_SOCKET;
 	int fd;
 	struct sockaddr_un addr;
 	int ret = 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,34 +13,19 @@
 include(Dart)
 
 execute_process(COMMAND ${APXS_EXECUTABLE} -q progname
-  OUTPUT_VARIABLE APXS_PROGNAME
+  OUTPUT_VARIABLE HTTPD_PROGNAME
   OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 find_package(UnixCommands REQUIRED)
 find_program(CAT_EXECUTABLE NAMES cat REQUIRED)
 find_program(CURL_EXECUTABLE NAMES curl REQUIRED)
-find_program(HTTPD_EXECUTABLE NAMES ${APXS_PROGNAME} REQUIRED)
+find_program(HTTPD_EXECUTABLE NAMES ${HTTPD_PROGNAME} REQUIRED)
 find_program(ID_EXECUTABLE NAMES id REQUIRED)
 find_program(KILL_EXECUTABLE NAMES kill REQUIRED)
 find_program(MKDIR_EXECUTABLE NAMES mkdir REQUIRED)
 find_program(SHA256SUM_EXECUTABLE NAMES gsha256sum sha256sum REQUIRED)
 find_program(TOUCH_EXECUTABLE NAMES gtouch touch REQUIRED)
-
-if(LibMapnik_VERSION STRLESS "4")
-  find_program(MAPNIK_CONFIG_EXECUTABLE NAMES mapnik-config REQUIRED)
-  execute_process(COMMAND ${MAPNIK_CONFIG_EXECUTABLE} --fonts
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE MAPNIK_FONTS_DIR
-  )
-  execute_process(COMMAND ${MAPNIK_CONFIG_EXECUTABLE} --input-plugins
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    OUTPUT_VARIABLE MAPNIK_PLUGINS_DIR
-  )
-elseif(LibMapnik_VERSION STRGREATER_EQUAL "4")
-  pkg_get_variable(MAPNIK_FONTS_DIR libmapnik fonts_dir)
-  pkg_get_variable(MAPNIK_PLUGINS_DIR libmapnik plugins_dir)
-endif()
 
 execute_process(COMMAND ${ID_EXECUTABLE} -gn nobody
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -66,24 +51,6 @@ configure_file(
 configure_file(
   httpd.conf.in
   conf/httpd.conf
-)
-
-configure_file(
-  ../utils/example-map/index.html
-  www/index.html
-  COPYONLY
-)
-
-configure_file(
-  ../utils/example-map/mapnik.xml
-  www/mapnik.xml
-  COPYONLY
-)
-
-configure_file(
-  ../utils/example-map/very_simplified_land_polygons.gpkg
-  www/very_simplified_land_polygons.gpkg
-  COPYONLY
 )
 
 #-----------------------------------------------------------------------------

--- a/tests/httpd.conf.in
+++ b/tests/httpd.conf.in
@@ -1,8 +1,8 @@
-Alias /renderd-example-map @PROJECT_BINARY_DIR@/tests/www
+Alias /renderd-example-map @PROJECT_SOURCE_DIR@/utils/example-map
 Redirect /renderd-example-map/leaflet/leaflet.css https://unpkg.com/leaflet/dist/leaflet.css
 Redirect /renderd-example-map/leaflet/leaflet.min.js https://unpkg.com/leaflet/dist/leaflet.js
 
-<Directory @PROJECT_BINARY_DIR@/tests/www>
+<Directory @PROJECT_SOURCE_DIR@/utils/example-map>
   Allow from all
   AllowOverride All
   DirectoryIndex index.html
@@ -70,23 +70,23 @@ ServerRoot @PROJECT_BINARY_DIR@/tests
 User nobody
 
 <IfModule !access_compat_module>
-  LoadModule access_compat_module @HTTPD_MODULES_DIR@/mod_access_compat.so
+  LoadModule access_compat_module @HTTPD_LIBEXECDIR@/mod_access_compat.so
 </IfModule>
 <IfModule !alias_module>
-  LoadModule alias_module @HTTPD_MODULES_DIR@/mod_alias.so
+  LoadModule alias_module @HTTPD_LIBEXECDIR@/mod_alias.so
 </IfModule>
 <IfModule !authz_core_module>
-  LoadModule authz_core_module @HTTPD_MODULES_DIR@/mod_authz_core.so
+  LoadModule authz_core_module @HTTPD_LIBEXECDIR@/mod_authz_core.so
 </IfModule>
 <IfModule !dir_module>
-  LoadModule dir_module @HTTPD_MODULES_DIR@/mod_dir.so
+  LoadModule dir_module @HTTPD_LIBEXECDIR@/mod_dir.so
 </IfModule>
 <IfModule !log_config_module>
-  LoadModule log_config_module @HTTPD_MODULES_DIR@/mod_log_config.so
+  LoadModule log_config_module @HTTPD_LIBEXECDIR@/mod_log_config.so
 </IfModule>
 <IfModule !mpm_event_module>
-  LoadModule mpm_event_module @HTTPD_MODULES_DIR@/mod_mpm_event.so
+  LoadModule mpm_event_module @HTTPD_LIBEXECDIR@/mod_mpm_event.so
 </IfModule>
 <IfModule !unixd_module>
-  LoadModule unixd_module @HTTPD_MODULES_DIR@/mod_unixd.so
+  LoadModule unixd_module @HTTPD_LIBEXECDIR@/mod_unixd.so
 </IfModule>

--- a/tests/renderd.conf.in
+++ b/tests/renderd.conf.in
@@ -1,12 +1,12 @@
 [mapnik]
-font_dir_recurse=true
 font_dir=@MAPNIK_FONTS_DIR@
+font_dir_recurse=@MAPNIK_FONTS_DIR_RECURSE@
 plugins_dir=@MAPNIK_PLUGINS_DIR@
 
 [@MAP_NAME@]
 TILEDIR=@PROJECT_BINARY_DIR@/tests/tiles
 URI=/tiles/renderd-example
-XML=@PROJECT_BINARY_DIR@/tests/www/mapnik.xml
+XML=@PROJECT_SOURCE_DIR@/utils/example-map/mapnik.xml
 
 [renderd1]
 iphostname=127.0.0.1


### PR DESCRIPTION
Since most of the variables contained within config files and related to directory destinations are available at build time, they can be used to generate and install some of the config files and directories.

* `/etc/renderd.conf`
  * Basic `renderd` configuration file with `renderd` & `mapnik` sections
* `/etc/apache2/mods-available/tile.load` (path varies based on OS/Distribution)
  * Apache HTTP server `LoadModule` directive configuration file
* `/var/run/renderd`
* `/var/cache/renderd/tiles`