### PR TITLE
Mapnik is now in FreeBSD's package repositories

### DIFF
--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -3,94 +3,37 @@ inputs:
   build-dependencies:
     default:  >-
       apache24
-      boost-all
       cairo
       ceph14
       cmake
       coreutils
       curl
-      freetype2
-      gdal
       glib
-      gmake
-      harfbuzz
-      icu
       iniparser
-      libjpeg-turbo
       libmemcached
-      png
-      proj
-      python39
-      sqlite3
-      tiff
-      webp
-      zlib-ng
+      mapnik
+      pkgconf
     description: List of build dependency package(s) to install
-  mapnik-version:
-    default: 3.1.0
-    description: Version of Mapnik to build & install
-  python-version:
-    default: 3.9
-    description: Version of Python
 
 runs:
   using: composite
   steps:
-    - name: Create `Mapnik` source directory
-      run: |
-        mkdir mapnik-src
-      shell: bash --noprofile --norc -euxo pipefail {0}
-
-    - name: Cache `Mapnik` source directory
-      id: cache-mapnik-src
-      uses: actions/cache@v3
-      with:
-        path: mapnik-src
-        key: freebsd-vm:0.3.0-LLVM-mapnik-${{ inputs.mapnik-version }}
-
-    - name: Download `Mapnik`
-      run: |
-        curl --location --silent \
-          https://github.com/mapnik/mapnik/releases/download/v${{ inputs.mapnik-version }}/mapnik-v${{ inputs.mapnik-version }}.tar.bz2 \
-          | tar --extract --bzip2 --strip-components=1 --file=-
-        curl --location --silent \
-          https://github.com/mapnik/mapnik/commit/8944e81367d2b3b91a41e24116e1813c01491e5d.patch \
-          | patch -F3 -Np1
-        curl --location --silent \
-          https://github.com/mapnik/mapnik/commit/83779b7b6bdd229740b1b5e12a4a8fe27114cb7d.patch \
-          | patch -F3 -Np1
-        curl --location --silent \
-          https://github.com/mapnik/mapnik/commit/7f0daee8b37d8cf6eff32529b1762ffd5104f3f3.patch \
-          | patch -F3 -Np1
-      shell: bash --noprofile --norc -euxo pipefail {0}
-      working-directory: mapnik-src
-      if: steps.cache-mapnik-src.outputs.cache-hit != 'true'
-
     - name: Install dependencies, Build, Test & Install `mod_tile`
       uses: vmactions/freebsd-vm@v0.3.0
       with:
         mem: 4096
         prepare: |
-          pkg install --yes ${{ inputs.build-dependencies }}
+          mkdir -p /usr/local/etc/pkg/repos
+          sed 's#/quarterly#/latest#g' /etc/pkg/FreeBSD.conf > /usr/local/etc/pkg/repos/FreeBSD.conf
           pkg upgrade --yes
-          set JOBS=`sysctl -n hw.ncpu`
-          setenv JOBS ${JOBS}
-          setenv PYTHON python${{ inputs.python-version }}
-          cd ${GITHUB_WORKSPACE}/mapnik-src
-          sh configure \
-            CPP_TESTS=False \
-            DEMO=False \
-            FAST=True \
-            HB_INCLUDES=/usr/local/include/harfbuzz \
-            HB_LIBS=/usr/local/lib \
-            ICU_INCLUDES=/usr/local/include \
-            ICU_LIBS=/usr/local/lib \
-            OPTIMIZATION=0 && \
-          gmake PYTHON=${PYTHON} && \
-          gmake install PYTHON=${PYTHON}
+          pkg install --yes ${{ inputs.build-dependencies }}
         release: 13.1
         run: |
-          cmake -S . -B build -DCMAKE_LIBRARY_PATH=/usr/local/lib -DENABLE_TESTS=1
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)
+          cmake -B build -S . \
+            -DCMAKE_LIBRARY_PATH:PATH=/usr/local/lib \
+            -DENABLE_TESTS:BOOL=ON
           cmake --build build
           ctest --test-dir build
           cmake --install build
+        usesh: true


### PR DESCRIPTION
So it no longer needs to be built in order to test `mod_tile`, this will greatly speed up `FreeBSD` jobs in GitHub CI.
(From @ 30 minutes to @ 10 minutes)

Mapnik added here:
https://github.com/freebsd/freebsd-ports/commit/84c697c41d13d0bc8d1fe1cf9d6f81410c77630f