### PR TITLE
Make macOS 13 the default macOS version in GitHub Actions

### DIFF
--- a/.github/actions/dependencies/install/action.yml
+++ b/.github/actions/dependencies/install/action.yml
@@ -55,6 +55,7 @@ inputs:
       iniparser
       libmemcached
       mapnik
+      pkg-config
   macos-test-dependencies:
     default: >-
       coreutils

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -97,6 +97,7 @@ jobs:
       matrix:
         image:
           - macos-11
+          - macos-12
         build_system:
           - CMake
         compiler:
@@ -104,10 +105,10 @@ jobs:
         on_default_branch:
           - ${{ contains(github.ref, 'master') || contains(github.ref, 'develop') }}
         include:
-          - image: macos-12
+          - image: macos-13
             build_system: Autotools
             compiler: LLVM
-          - image: macos-12
+          - image: macos-13
             build_system: CMake
             compiler: LLVM
         exclude:


### PR DESCRIPTION
Available since April 24th, 2023:
https://github.blog/changelog/2023-04-24-github-actions-macos-13-is-now-available/

This version of `macOS` seems to generally run a few minutes faster, about 6-9 minutes total rather than 11-14 minutes.