### PR TITLE
Replace `Fedora 36` with `Fedora 38` in GitHub Actions

### DIFF
--- a/.github/actions/cmake/build/action.yml
+++ b/.github/actions/cmake/build/action.yml
@@ -11,11 +11,11 @@ runs:
 
     - name: Prepare `build` directory
       run: |
-        cmake -S . -B build \
+        cmake -B build -S . \
           -LA \
-          -DCMAKE_BUILD_TYPE=${BUILD_TYPE:-Debug} \
-          -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX:-/usr/local} \
-          -DENABLE_TESTS=1
+          -DCMAKE_BUILD_TYPE:STRING=${BUILD_TYPE:-Debug} \
+          -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX:-/usr/local} \
+          -DENABLE_TESTS:BOOL=ON
       shell: bash --noprofile --norc -euxo pipefail {0}
 
     - name: Build `mod_tile`

--- a/.github/actions/dependencies/build-and-install/mapnik/latest/action.yml
+++ b/.github/actions/dependencies/build-and-install/mapnik/latest/action.yml
@@ -25,7 +25,7 @@ runs:
         cmake -S mapnik-src -B mapnik-build \
           -DBUILD_DEMO_VIEWER:BOOL=OFF \
           -DBUILD_TESTING:BOOL=OFF \
-          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_BUILD_TYPE:STRING=Release \
           -DCMAKE_INSTALL_PREFIX:PATH=/usr
         cmake --build mapnik-build
       shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/dependencies/install/action.yml
+++ b/.github/actions/dependencies/install/action.yml
@@ -78,7 +78,7 @@ inputs:
       gdal-devel
       harfbuzz-devel
       libicu-devel
-      libjpeg-turbo-devel
+      libjpeg-devel
       libpng-devel
       libtiff-devel
       libwebp-devel

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,8 +20,8 @@ jobs:
           - 'debian:10'
           - 'debian:11'
           - 'debian:testing'
-          - 'fedora:36'
           - 'fedora:37'
+          - 'fedora:38'
           - 'fedora:rawhide'
           - 'ubuntu:20.04'
         build_system:


### PR DESCRIPTION
* `Fedora 38` released on `2023-04-18`
* `Fedora 36` EOLed on `2023-05-16`

See [here](https://github.com/hummeltech/mod_tile/actions/runs/5190297895) for an example GitHub Actions workflow run.