### PR TITLE
Replace `Debian 10` with `Debian 12` in GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,8 +17,8 @@ jobs:
       matrix:
         image:
           - 'centos:7'
-          - 'debian:10'
           - 'debian:11'
+          - 'debian:12'
           - 'debian:testing'
           - 'fedora:36'
           - 'fedora:37'
@@ -45,7 +45,7 @@ jobs:
           - image: 'ubuntu:22.04'
             build_system: CMake
             compiler: LLVM
-          - image: 'debian:11'
+          - image: 'debian:12'
             build_system: CMake
             compiler: GNU
             mapnik_latest: true


### PR DESCRIPTION
* `Debian 12` released on `2023-06-10`
* `Debian 10` security updates were discontinued on `2022-06-30`