### PR TITLE
Fixed various CI failures

### DIFF
--- a/.github/actions/cmake/build/action.yml
+++ b/.github/actions/cmake/build/action.yml
@@ -13,7 +13,7 @@ runs:
       run: |
         cmake -B build -S . \
           -LA \
-          -DCMAKE_BUILD_TYPE:STRING=${BUILD_TYPE:-Debug} \
+          -DCMAKE_BUILD_TYPE:STRING=${BUILD_TYPE:-Release} \
           -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX:-/usr/local} \
           -DENABLE_TESTS:BOOL=ON
       shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/dependencies/install/yum/action.yml
+++ b/.github/actions/dependencies/install/yum/action.yml
@@ -48,5 +48,10 @@ runs:
       shell: bash --noprofile --norc -euxo pipefail {0}
 
     - name: Install package(s)
-      run: yum --assumeyes --skip-broken install ${{ inputs.packages }}
+      run: |
+        if command -v dnf5 &> /dev/null; then
+          yum --assumeyes install ${{ inputs.packages }}
+        else
+          yum --assumeyes --skip-broken install ${{ inputs.packages }}
+        fi
       shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -30,8 +30,11 @@ runs:
         release: 13.1
         run: |
           export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)
+          export LIBRARY_PATH=/usr/local/lib
           cmake -B build -S . \
-            -DCMAKE_LIBRARY_PATH:PATH=/usr/local/lib \
+            -LA \
+            -DCMAKE_BUILD_TYPE:STRING=${BUILD_TYPE:-Release} \
+            -DCMAKE_INSTALL_PREFIX:PATH=${INSTALL_PREFIX:-/usr/local} \
             -DENABLE_TESTS:BOOL=ON
           cmake --build build
           ctest --test-dir build

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -58,7 +58,6 @@ jobs:
       fail-fast: false
     container:
       env:
-        BUILD_TYPE: Debug
         CC: ${{ matrix.compiler == 'LLVM' && 'clang' || 'gcc' }}
         CFLAGS: ${{ (matrix.build_system == 'CMake' && matrix.compiler == 'GNU') && '--coverage' || '' }}
         CXX: ${{ matrix.compiler == 'LLVM' && 'clang++' || 'g++' }}
@@ -86,7 +85,6 @@ jobs:
 
   macOS:
     env:
-      BUILD_TYPE: Release
       CFLAGS: -Wno-implicit-function-declaration
       LDFLAGS: -undefined dynamic_lookup
       LIBRARY_PATH: /usr/local/lib

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ jobs:
     name: Build, Test & Report Coverage
     runs-on: ubuntu-latest
     env:
+      BUILD_TYPE: Debug
       CFLAGS: --coverage
       CXXFLAGS: --coverage
     steps:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -146,23 +146,23 @@ add_test(
   NAME download_tiles
   COMMAND ${BASH} -c "
     until $(${TILE_DEFAULT_CMD} --output tile.png); do
-      echo 'Sleeping 1s';
+      echo 'Sleeping 1s (DEFAULT)';
       sleep 1;
     done
     until $(${TILE_JPG_CMD} --output tile.jpg); do
-      echo 'Sleeping 1s';
+      echo 'Sleeping 1s (JPG)';
       sleep 1;
     done
     until $(${TILE_PNG256_CMD} --output tile.png256); do
-      echo 'Sleeping 1s';
+      echo 'Sleeping 1s (PNG256)';
       sleep 1;
     done
     until $(${TILE_PNG32_CMD} --output tile.png32); do
-      echo 'Sleeping 1s';
+      echo 'Sleeping 1s (PNG32)';
       sleep 1;
     done
     until $(${TILE_WEBP_CMD} --output tile.webp); do
-      echo 'Sleeping 1s';
+      echo 'Sleeping 1s (WEBP)';
       sleep 1;
     done
   "

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,8 +55,9 @@ set(TILE_PNG256_SHA256SUM "${TILE_DEFAULT_SHA256SUM}")
 set(TILE_PNG32_CMD "${CURL_EXECUTABLE} --fail --silent ${TILE_PNG32_URL}")
 set(TILE_PNG32_SHA256SUM "1006d92152f1e18896e0016fb43201b14bbcf7655955b74495ad3610541d325b")
 set(TILE_WEBP_CMD "${CURL_EXECUTABLE} --fail --silent ${TILE_WEBP_URL}")
-set(TILE_WEBP_SHA256SUM_6 "96fc0455b2269a7bcd4a5b3c9844529c3c77e3bb15f56e72f78a5af3bc15b6b5") # libwebp6
-set(TILE_WEBP_SHA256SUM_7 "a82ef9ba5dc333de88af7b645084c30ab2b01c664e17162cbf6659c287cc4df4") # libwebp7
+set(TILE_WEBP_SHA256SUM_4 "ef3862a57831b21ec69c15be196e1e2b4fea66246c361142631b9fa22b85decc") # libwebp.so.4
+set(TILE_WEBP_SHA256SUM_6 "96fc0455b2269a7bcd4a5b3c9844529c3c77e3bb15f56e72f78a5af3bc15b6b5") # libwebp.so.6
+set(TILE_WEBP_SHA256SUM_7 "a82ef9ba5dc333de88af7b645084c30ab2b01c664e17162cbf6659c287cc4df4") # libwebp.so.7
 
 configure_file(
   renderd.conf.in
@@ -174,7 +175,7 @@ add_test(
     (echo '${TILE_JPG_SHA256SUM}  tile.jpg' | ${SHA256SUM_EXECUTABLE} -c) && \
     (echo '${TILE_PNG256_SHA256SUM}  tile.png256' | ${SHA256SUM_EXECUTABLE} -c) && \
     (echo '${TILE_PNG32_SHA256SUM}  tile.png32' | ${SHA256SUM_EXECUTABLE} -c) && \
-    ((echo '${TILE_WEBP_SHA256SUM_6}  tile.webp' | ${SHA256SUM_EXECUTABLE} -c) || (echo '${TILE_WEBP_SHA256SUM_7}  tile.webp' | ${SHA256SUM_EXECUTABLE} -c))
+    ((echo '${TILE_WEBP_SHA256SUM_7}  tile.webp' | ${SHA256SUM_EXECUTABLE} -c) || (echo '${TILE_WEBP_SHA256SUM_6}  tile.webp' | ${SHA256SUM_EXECUTABLE} -c) || (echo '${TILE_WEBP_SHA256SUM_4}  tile.webp' | ${SHA256SUM_EXECUTABLE} -c))
   "
 )
 add_test(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -255,12 +255,12 @@ set_tests_properties(render_expired PROPERTIES
 set_tests_properties(render_list PROPERTIES
   DEPENDS render_speedtest
   FIXTURES_REQUIRED httpd_started
-  TIMEOUT 20
+  TIMEOUT 60
 )
 set_tests_properties(render_old PROPERTIES
   DEPENDS render_speedtest
   FIXTURES_REQUIRED httpd_started
-  TIMEOUT 20
+  TIMEOUT 60
 )
 set_tests_properties(download_tiles PROPERTIES
   FIXTURES_REQUIRED httpd_started

--- a/tests/renderd.conf.in
+++ b/tests/renderd.conf.in
@@ -12,25 +12,25 @@ XML=@PROJECT_SOURCE_DIR@/utils/example-map/mapnik.xml
 TILEDIR=@PROJECT_BINARY_DIR@/tests/tiles
 TYPE=jpg image/jpeg jpeg
 URI=/tiles/renderd-example-jpg
-XML=@PROJECT_BINARY_DIR@/tests/www/mapnik.xml
+XML=@PROJECT_SOURCE_DIR@/utils/example-map/mapnik.xml
 
 [@MAP_NAME@_png256]
 TILEDIR=@PROJECT_BINARY_DIR@/tests/tiles
 TYPE=png image/png png256
 URI=/tiles/renderd-example-png256
-XML=@PROJECT_BINARY_DIR@/tests/www/mapnik.xml
+XML=@PROJECT_SOURCE_DIR@/utils/example-map/mapnik.xml
 
 [@MAP_NAME@_png32]
 TILEDIR=@PROJECT_BINARY_DIR@/tests/tiles
 TYPE=png image/png png32
 URI=/tiles/renderd-example-png32
-XML=@PROJECT_BINARY_DIR@/tests/www/mapnik.xml
+XML=@PROJECT_SOURCE_DIR@/utils/example-map/mapnik.xml
 
 [@MAP_NAME@_webp]
 TILEDIR=@PROJECT_BINARY_DIR@/tests/tiles
 TYPE=webp image/webp webp
 URI=/tiles/renderd-example-webp
-XML=@PROJECT_BINARY_DIR@/tests/www/mapnik.xml
+XML=@PROJECT_SOURCE_DIR@/utils/example-map/mapnik.xml
 
 [renderd1]
 iphostname=127.0.0.1


### PR DESCRIPTION
* Fix `Unknown argument "--skip-broken" for command "dnf5"` (`fedora:rawhide`)
* Increase timeout for `render_list` & `render_old` tests (`centos:7`)
* Add support for testing with `libwebp.so.4` (`centos:7`)
* Sync FreeBSD build command with others (and build Release by default)
* Fix non-default (I.E. `.jpg`/`.webp`/etc.) tile tests
  * `mapnik.xml` file was no longer being copied to `@PROJECT_BINARY_DIR@` since [this commit](https://github.com/hummeltech/mod_tile/commit/6e20fba5e9817cd16c41943b223f47c461288f5a#diff-c0b18b5ea11fcb76f961f9651a40e5d596a11c1ab7076f8f9c43402e19fc7858L6-L10)