### PR TITLE
Resolve deprecation of CMake module `FindDart`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@
 #
 #-----------------------------------------------------------------------------
 
-include(Dart)
+include(CTest)
 
 execute_process(COMMAND ${APXS_EXECUTABLE} -q progname
   OUTPUT_VARIABLE HTTPD_PROGNAME


### PR DESCRIPTION
* Deprecated with [CMake 3.27](https://cmake.org/cmake/help/latest/module/FindDart.html), which is currently only present in `Fedora Rawhide`
  * [Before](https://github.com/hummeltech/mod_tile/actions/runs/5618193893/job/15223412223#step:6:63)
  * [After](https://github.com/hummeltech/mod_tile/actions/runs/5624575307/job/15241662030#step:6:63)