### PR TITLE
Pre-load fonts so map's local font cache is populated

### DIFF
--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -305,6 +305,8 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char
 
 			map->parameterize_function(map_parameterized, options);
 
+			map_parameterized.load_fonts();
+
 			mapnik::agg_renderer<mapnik::image_32> ren(map_parameterized, buf, map->scale);
 			ren.apply();
 		} else {
@@ -423,6 +425,10 @@ void *render_thread(void * arg)
 
 			try {
 				mapnik::load_map(maps[iMaxConfigs].map, maps[iMaxConfigs].xmlfile);
+
+				if (!maps[iMaxConfigs].parameterize_function) {
+					maps[iMaxConfigs].map.load_fonts();
+				}
 
 				/* If we have more than 10 rendering threads configured, we need to fix
 				 * up the mapnik datasources to support larger postgres connection pools

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -300,14 +300,17 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char
 	mapnik::image_32 buf(render_size_tx * map->tilesize, render_size_ty * map->tilesize);
 
 	try {
-		Map map_parameterized = map->map;
-
 		if (map->parameterize_function) {
-			map->parameterize_function(map_parameterized, options);
-		}
+			Map map_parameterized = map->map;
 
-		mapnik::agg_renderer<mapnik::image_32> ren(map_parameterized, buf, map->scale);
-		ren.apply();
+			map->parameterize_function(map_parameterized, options);
+
+			mapnik::agg_renderer<mapnik::image_32> ren(map_parameterized, buf, map->scale);
+			ren.apply();
+		} else {
+			mapnik::agg_renderer<mapnik::image_32> ren(map->map, buf, map->scale);
+			ren.apply();
+		}
 	} catch (std::exception const& ex) {
 		g_logger(G_LOG_LEVEL_ERROR, "failed to render TILE %s %d %d-%d %d-%d", map->xmlname, z, x, x + render_size_tx - 1, y, y + render_size_ty - 1);
 		g_logger(G_LOG_LEVEL_ERROR, "  reason: %s", ex.what());


### PR DESCRIPTION
If the local font cache is not populated then mapnik falls back to trying to use the global cache which is buggy and has nasty lock contention issues (https://github.com/mapnik/mapnik/issues/4406) so we want to call `load_fonts` on the map to populate it.

Because copying map objects discards the cache we want to avoid doing that unless we have to, and when we do have to because the map is parameterized we defer loading the fonts until after the copy is made.