### PR TITLE
Increase queue limits to reflect modern machines

### DIFF
--- a/includes/render_config.h
+++ b/includes/render_config.h
@@ -110,8 +110,8 @@
 // Metatiles are much larger in size so we don't need big queues to handle large areas
 #ifdef METATILE
 #define QUEUE_MAX (64)
-#define REQ_LIMIT (32)
-#define DIRTY_LIMIT (1000)
+#define REQ_LIMIT (256)
+#define DIRTY_LIMIT (8000)
 
 #else
 #define QUEUE_MAX (1024)


### PR DESCRIPTION
When these limits were set in 2008 (a16d3b7) it would take a few minutes to clear through the dirty tile queue, giving it the ability to even out load over a few minute timescale, and let the work in the queue be done when the server is no longer busy. These days, a server can clear through 1000 metatiles in seconds, meaning the queue fills up nearly instantly and starts dropping tiles.

Increasing these limits by 8x attempts to restore some of the old utility of the queue.

By my estimates, in 2008 a server might have been doing 5 metatiles/second, while now it's 100 metatiles/second.

If we were starting over, I wouldn't consider the gains of having the queue worth the additional code complexity.