### PR TITLE
Fixed FreeBSD CI build failure

### DIFF
--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -4,7 +4,6 @@ inputs:
     default:  >-
       apache24
       cairo
-      ceph14
       cmake
       coreutils
       curl


### PR DESCRIPTION
The `ceph14` package has been marked as `broken` and is therefore no longer available:

https://github.com/freebsd/freebsd-ports/commit/02f9ff5be452447269234bad74d082c102a8e8d1

This is causing errors such as this:

https://github.com/openstreetmap/mod_tile/actions/runs/6322159276/job/17167290842#step:3:1249