### PR TITLE
Fixed FreeBSD CI build failure

### DIFF
--- a/.github/actions/freebsd/action.yml
+++ b/.github/actions/freebsd/action.yml
@@ -9,7 +9,6 @@ inputs:
       curl
       glib
       iniparser
-      libmemcached
       mapnik
       pkgconf
     description: List of build dependency package(s) to install


### PR DESCRIPTION
There seems to have been a change to `libmemcached` which is causing CI build failures, I.E.:
https://github.com/openstreetmap/mod_tile/actions/runs/6341651339/job/17226108997#step:3:1925

This appears to be the source of the issue:
https://cgit.freebsd.org/ports/commit/?id=c25f0c013e88d84c620b2bb8c56158e9ca7f8bef