### PR TITLE
Allow FreeBSD job to fail

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -133,6 +133,7 @@ jobs:
         uses: ./.github/actions/install
 
   FreeBSD:
+    continue-on-error: true
     env:
       BUILD_PARALLEL_LEVEL: 4
       LIBRARY_PATH: /usr/local/lib


### PR DESCRIPTION
FreeBSD's `mapnik` package is currently not being built due to some minor errors, once it is fixed, this job will begin to pass again.

https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=274166