### PR TITLE
Fix CentOS 7 CI job not working with `actions/checkout@v4`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,8 +66,13 @@ jobs:
         run: yum --assumeyes install git
         if: matrix.image == 'amazonlinux:2'
 
+      - name: Checkout code (CentOS 7)
+        uses: actions/checkout@v3
+        if: matrix.image == 'centos:7'
+
       - name: Checkout code
         uses: actions/checkout@v4
+        if: matrix.image != 'centos:7'
 
       - name: Install dependencies
         uses: ./.github/actions/dependencies/install


### PR DESCRIPTION
Currently failing:
```
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)
```