### PR TITLE
cope with recv returning fewer bytes than expected

### DIFF
--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -314,52 +314,57 @@ static int request_tile(request_rec *r, struct protocol *cmd, int renderImmediat
 		struct pollfd rx;
 		int s;
 
+		size_t already_read = 0;
+		size_t want = sizeof(struct protocol_v2);
+		bzero(&resp, sizeof(struct protocol));
+
 		while (1) {
 			rx.fd = fd;
 			rx.events = POLLIN;
 			s = poll(&rx, 1, timeout * 1000);
 
 			if (s > 0) {
-				bzero(&resp, sizeof(struct protocol));
-				ret = recv(fd, &resp, sizeof(struct protocol_v2), 0);
+				ret = recv(fd, &resp + already_read, want - already_read, 0);
 
-				if (ret != sizeof(struct protocol_v2)) {
-					ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r, "request_tile: Failed to read response from rendering socket. Got %d bytes but expected %d. Errno %d (%s)",
-						      ret, (int) sizeof(struct protocol_v2), errno, strerror(errno));
+				if (ret == sizeof(struct protocol_v2)) {
+					ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r, "request_tile: Failed to read response from rendering socket: %s",
+						strerror(errno));
 					break;
 				}
+				already_read += ret;
+				want = (resp.ver == 3) ? sizeof(struct protocol) : sizeof(struct protocol_v2);
 
-				if (resp.ver == 3) {
-					ret += recv(fd, ((void*)&resp) + sizeof(struct protocol_v2), sizeof(struct protocol) - sizeof(struct protocol_v2), 0);
-				}
+				if (already_read == want) {
+					if (cmd->x == resp.x && cmd->y == resp.y && cmd->z == resp.z && !strcmp(cmd->xmlname, resp.xmlname)) {
+				        close(fd);
 
-				if (cmd->x == resp.x && cmd->y == resp.y && cmd->z == resp.z && !strcmp(cmd->xmlname, resp.xmlname)) {
-					close(fd);
-
-					if (resp.cmd == cmdDone) {
-						return 1;
+						if (resp.cmd == cmdDone) {
+							return 1;
+						} else {
+							return 0;
+						}
 					} else {
-						return 0;
+						ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
+							  "Response does not match request: xml(%s,%s) z(%d,%d) x(%d,%d) y(%d,%d)", cmd->xmlname,
+							  resp.xmlname, cmd->z, resp.z, cmd->x, resp.x, cmd->y, resp.y);
 					}
-				} else {
-					ap_log_rerror(APLOG_MARK, APLOG_WARNING, 0, r,
-						      "Response does not match request: xml(%s,%s) z(%d,%d) x(%d,%d) y(%d,%d)", cmd->xmlname,
-						      resp.xmlname, cmd->z, resp.z, cmd->x, resp.x, cmd->y, resp.y);
+					already_read = 0;
+					want = sizeof(struct protocol_v2);
 				}
 			} else if (s == 0) {
 				ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r,
-					      "request_tile: Request xml(%s) z(%d) x(%d) y(%d) could not be rendered in %i seconds",
-					      cmd->xmlname, cmd->z, cmd->x, cmd->y,
-					      timeout);
+                    "request_tile: Request xml(%s) z(%d) x(%d) y(%d) could not be rendered in %i seconds",
+                        cmd->xmlname, cmd->z, cmd->x, cmd->y,
+                        timeout);
 				break;
 			} else {
 				ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r,
-					      "request_tile: Request xml(%s) z(%d) x(%d) y(%d) timeout %i seconds failed with reason: %s",
-					      cmd->xmlname, cmd->z, cmd->x, cmd->y,
-					      timeout, strerror(errno));
+                    "request_tile: Request xml(%s) z(%d) x(%d) y(%d) timeout %i seconds failed with reason: %s",
+                        cmd->xmlname, cmd->z, cmd->x, cmd->y,
+                        timeout, strerror(errno));
 				break;
 			}
-		}
+        }
 	}
 
 	close(fd);


### PR DESCRIPTION
When the `poll` system call signals readability on a socket, there is no guarantee that more than one byte is actually readable. In 99.9% of cases you will be able whatever the OS's internal buffer size is - something like 4k - and this will be more than enough for a mod_tile message. But you cannot rely on that. Assuming that `recv` will always return at least `sizeof (struct protocol_v2)` and throwing an error otherwise is bad design.

This pull request makes mod_tile concatenate the results of several `recv` calls until the desired number of bytes has been read.