### PR TITLE
FreeBSD quarterly repo is now missing `mapnik`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -181,6 +181,13 @@ jobs:
           cpus: ${{ env.BUILD_PARALLEL_LEVEL }}
           memory: 4096
 
+      # Mapnik is not in the `quarterly` repository (2023.10.12)
+      - name: Use "latest" repository
+        run: |
+          sudo mkdir -p /usr/local/etc/pkg/repos
+          sed 's#/quarterly#/latest#g' /etc/pkg/FreeBSD.conf | sudo tee /usr/local/etc/pkg/repos/FreeBSD.conf
+          sudo pkg upgrade
+
       - name: Install dependencies
         uses: ./.github/actions/dependencies/install
 

--- a/docs/build/building_on_freebsd.md
+++ b/docs/build/building_on_freebsd.md
@@ -9,6 +9,10 @@ Please see our [Continuous Integration script](/.github/workflows/build-and-test
 ```shell
 #!/usr/bin/env sh
 
+# Mapnik is not in the `quarterly` repository (2023.10.12)
+sudo mkdir -p /usr/local/etc/pkg/repos
+sudo sed 's#/quarterly#/latest#g' /etc/pkg/FreeBSD.conf > /usr/local/etc/pkg/repos/FreeBSD.conf
+
 # Update installed packages
 sudo pkg upgrade --yes
 


### PR DESCRIPTION
Mapnik v3.1.0 requires a patch in order to support Boost v1.8.3.

A fix has been applied, but has not yet made it into the quarterly repository:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=274166