### PR TITLE
Fix macOS `cmake --install` command failing due to `Read-only file system`

### DIFF
--- a/docs/build/building_on_macos.md
+++ b/docs/build/building_on_macos.md
@@ -43,7 +43,7 @@ cmake -B . -S /tmp/mod_tile_src \
   -DENABLE_TESTS:BOOL=ON
 cmake --build .
 ctest
-sudo cmake --install . --strip
+sudo cmake --install . --prefix /usr/local --strip
 
 # Create /usr/local/share/renderd directory
 sudo mkdir -p /usr/local/share/renderd

--- a/docs/build/building_on_macos.md
+++ b/docs/build/building_on_macos.md
@@ -43,7 +43,7 @@ cmake -B . -S /tmp/mod_tile_src \
   -DENABLE_TESTS:BOOL=ON
 cmake --build .
 ctest
-sudo cmake --install . --prefix /usr --strip
+sudo cmake --install . --strip
 
 # Create /usr/local/share/renderd directory
 sudo mkdir -p /usr/local/share/renderd


### PR DESCRIPTION
On `macOS`, the directory `/usr` is read-only (except for `/usr/local`, at least).

Resolves #349