### PR TITLE
Add a --no-progress switch to render_expired

### DIFF
--- a/docs/man/render_expired.1
+++ b/docs/man/render_expired.1
@@ -1,4 +1,4 @@
-.TH RENDER_EXPIRED 1 "May 21, 2022"
+.TH RENDER_EXPIRED 1 "Nov 25, 2023"
 .\" Please adjust this date whenever revising the manpage.
 .SH NAME
 render_expired \- expires a list of map tiles so that they get re-rendered.
@@ -64,6 +64,9 @@ When expiring tiles of ZOOM or higher, delete them instead of re-rendering (defa
 .TP
 \fB\-T\fR|\-\-touch-from=ZOOM
 when expiring tiles of ZOOM or higher, touch them instead of re-rendering (default is off)
+.TP
+\-\-no-progress
+Disable display of progress messages (default is off)
 .TP
 \fB\-h\fR|\-\-help
 Print out a help text for render_expired

--- a/src/render_expired.c
+++ b/src/render_expired.c
@@ -106,6 +106,7 @@ int main(int argc, char **argv)
 	int deleteFrom = -1;
 	int touchFrom = -1;
 	int doRender = 0;
+	int progress = 1;
 	int i;
 	struct storage_backend * store;
 	char name[PATH_MAX];
@@ -134,6 +135,7 @@ int main(int argc, char **argv)
 			{"socket",      required_argument, 0, 's'},
 			{"tile-dir",    required_argument, 0, 't'},
 			{"touch-from",  required_argument, 0, 'T'},
+			{"no-progress", no_argument,       0, 'N'},
 			{"verbose",     no_argument,       0, 'v'},
 
 			{"help",        no_argument,       0, 'h'},
@@ -212,6 +214,10 @@ int main(int argc, char **argv)
 
 			case 'l':   /* -l, --max-load */
 				maxLoad = atoi(optarg);
+				break;
+
+			case 'N':   /* --no-progress */
+				progress = 0;
 				break;
 
 			case 'v':   /* -v, --verbose */
@@ -333,7 +339,7 @@ int main(int argc, char **argv)
 		//printf("loop: x=%d y=%d z=%d up to z=%d\n", x, y, z, minZoom);
 		num_read++;
 
-		if (num_read % 100 == 0) {
+		if (progress && (num_read % 100) == 0) {
 			printf("Read and expanded %i tiles from list.\n", num_read);
 		}
 


### PR DESCRIPTION
When running `render_expired` as part of regular updates lots of progress messages just clog up the logs.