### PR TITLE
Fix build artifacts not uploading

### DIFF
--- a/.github/actions/cmake/test/action.yml
+++ b/.github/actions/cmake/test/action.yml
@@ -19,7 +19,7 @@ runs:
       run: |
         TAR_FILENAME=${{ matrix.image || matrix.os || github.job }}-${{ matrix.compiler }}.tar.gz
         TAR_FILENAME=$(echo "${TAR_FILENAME}" | sed 's/:/-/g')
-        tar -zcf ${{ runner.temp }}/${TAR_FILENAME} tests
+        tar -zcf ${TAR_FILENAME} tests
       shell: bash --noprofile --norc -euxo pipefail {0}
       working-directory: build
 
@@ -28,4 +28,4 @@ runs:
       uses: actions/upload-artifact@v3
       with:
         name: Test Artifacts
-        path: ${{ runner.temp }}/*.tar.gz
+        path: build/*.tar.gz


### PR DESCRIPTION
Apparently `${{ runner.temp }}` has a different value under certain circumstances