### PR TITLE
Improve FreeBSD CI Workflow

### DIFF
--- a/.github/actions/dependencies/install/action.yml
+++ b/.github/actions/dependencies/install/action.yml
@@ -260,7 +260,7 @@ runs:
           ${{ matrix.compiler == 'LLVM' && 'clang' || 'g++ gcc' }}
       if: |
         startsWith(matrix.image, 'ubuntu:') ||
-        (!matrix.image && runner.os == 'Linux')
+        (!matrix.image && github.job != 'FreeBSD' && runner.os == 'Linux')
 
     - name: Link `gcc`/`g++` (openSUSE)
       run: |

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -186,6 +186,7 @@ jobs:
     strategy:
       matrix:
         box_generic:
+          - freebsd12
           - freebsd13
         build_system:
           - CMake

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -182,7 +182,7 @@ jobs:
       ${{ matrix.box_generic }}
       (${{ matrix.build_system }})
       (${{ matrix.compiler }})
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         box_generic:
@@ -205,7 +205,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision VM
-        uses: hummeltech/freebsd-vagrant-action@v1.3
+        uses: hummeltech/freebsd-vagrant-action@v1.4
         with:
           box: generic/${{ matrix.box_generic }}
           cpus: ${{ env.BUILD_PARALLEL_LEVEL }}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ execute_process(COMMAND ${APXS_EXECUTABLE} -q progname
 find_package(UnixCommands REQUIRED)
 find_program(CAT_EXECUTABLE NAMES cat REQUIRED)
 find_program(CURL_EXECUTABLE NAMES curl REQUIRED)
+find_program(GREP_EXECUTABLE NAMES grep REQUIRED)
 find_program(HTTPD_EXECUTABLE NAMES ${HTTPD_PROGNAME} REQUIRED)
 find_program(ID_EXECUTABLE NAMES id REQUIRED)
 find_program(KILL_EXECUTABLE NAMES kill REQUIRED)
@@ -36,6 +37,7 @@ find_program(TOUCH_EXECUTABLE NAMES gtouch touch REQUIRED)
 set(MAP_NAME "default")
 set(HTTPD0_PORT "59980")
 set(HTTPD1_PORT "59981")
+set(RENDERD1_HOST "0.0.0.0")
 set(RENDERD1_PORT "59991")
 set(WWW_USER_NAME "nobody")
 
@@ -200,16 +202,23 @@ add_test(
 add_test(
   NAME dirty_tile
   COMMAND ${BASH} -c "
-    TILE_STATUS_CMD=\"${TILE_DEFAULT_CMD}/status | cut -d. -f2\"
-    TILE_STATUS_OUTPUT_OLD=$(\${TILE_STATUS_CMD})
+    TILE_STATUS_CMD=\"${TILE_DEFAULT_CMD}/status\"
+    TILE_LAST_RENDERED_AT_OLD=$(\${TILE_STATUS_CMD} | ${GREP_EXECUTABLE} -o 'Last rendered at [^\\.]*.')
+    echo \"Tile Last Rendered At (Old): \${TILE_LAST_RENDERED_AT_OLD}\"
     sleep 5;
-    TILE_DIRTY_OUTPUT=$(${TILE_DEFAULT_CMD}/dirty)
+    TILE_DIRTY_CMD=\"${TILE_DEFAULT_CMD}/dirty\"
+    TILE_DIRTY_OUTPUT=$(\${TILE_DIRTY_CMD})
+    echo \"Dirty: \${TILE_DIRTY_OUTPUT}\"
     if [ \"\${TILE_DIRTY_OUTPUT}\" != \"Tile submitted for rendering\" ]; then
       exit 1;
     fi
-    until [ \"\${TILE_STATUS_OUTPUT_OLD}\" != \"$(\${TILE_STATUS_CMD})\" ]; do
+    TILE_LAST_RENDERED_AT_NEW=$(\${TILE_STATUS_CMD} | ${GREP_EXECUTABLE} -o 'Last rendered at [^\\.]*.')
+    echo \"Tile Last Rendered At (New): \${TILE_LAST_RENDERED_AT_NEW}\"
+    until [ \"\${TILE_LAST_RENDERED_AT_OLD}\" != \"\${TILE_LAST_RENDERED_AT_NEW}\" ]; do
       echo 'Sleeping 1s';
       sleep 1;
+      TILE_LAST_RENDERED_AT_NEW=$(\${TILE_STATUS_CMD} | ${GREP_EXECUTABLE} -o 'Last rendered at [^\\.]*.');
+      echo \"Tile Last Rendered At (New): \${TILE_LAST_RENDERED_AT_NEW}\";
     done
   "
   WORKING_DIRECTORY tests
@@ -275,7 +284,7 @@ set_tests_properties(render_speedtest PROPERTIES
 set_tests_properties(render_expired PROPERTIES
   DEPENDS render_speedtest
   FIXTURES_REQUIRED httpd_started
-  TIMEOUT 20
+  TIMEOUT 60
 )
 set_tests_properties(render_list PROPERTIES
   DEPENDS render_speedtest
@@ -290,7 +299,7 @@ set_tests_properties(render_old PROPERTIES
 set_tests_properties(download_tiles PROPERTIES
   FIXTURES_REQUIRED httpd_started
   FIXTURES_SETUP tiles_downloaded
-  TIMEOUT 20
+  TIMEOUT 60
 )
 set_tests_properties(check_tiles PROPERTIES
   DEPENDS download_tiles
@@ -301,7 +310,7 @@ set_tests_properties(dirty_tile PROPERTIES
   DEPENDS download_tiles
   FIXTURES_REQUIRED "httpd_started;tiles_downloaded"
   REQUIRED_FILES "tile.png;tile.jpg;tile.png256;tile.png32;tile.webp"
-  TIMEOUT 20
+  TIMEOUT 60
 )
 set_tests_properties(remove_tiles PROPERTIES
   DEPENDS download_tiles

--- a/tests/httpd.conf.in
+++ b/tests/httpd.conf.in
@@ -51,7 +51,7 @@ Redirect /renderd-example-map/leaflet/leaflet.min.js https://unpkg.com/leaflet/d
   ModTileMaxLoadMissing 5
   ModTileMaxLoadOld 2
   ModTileMissingRequestTimeout 10
-  ModTileRenderdSocketAddr 127.0.0.1 @RENDERD1_PORT@
+  ModTileRenderdSocketAddr @RENDERD1_HOST@ @RENDERD1_PORT@
   ModTileRequestTimeout 3
   ModTileThrottlingRenders 128 0.2
   ModTileThrottlingTiles 10000 1

--- a/tests/renderd.conf.in
+++ b/tests/renderd.conf.in
@@ -33,7 +33,7 @@ URI=/tiles/renderd-example-webp
 XML=@PROJECT_SOURCE_DIR@/utils/example-map/mapnik.xml
 
 [renderd1]
-iphostname=127.0.0.1
+iphostname=@RENDERD1_HOST@
 ipport=@RENDERD1_PORT@
 pid_file=@PROJECT_BINARY_DIR@/tests/run/renderd1.pid
 stats_file=@PROJECT_BINARY_DIR@/tests/run/renderd1.stats


### PR DESCRIPTION
The `freebsd-vagrant-action` action now supports running on `Linux` runners, which almost halves the duration of `FreeBSD` building and testing.