### PR TITLE
Simplifed `docker/docker-compose.yml` file

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,185 +1,152 @@
 ---
 version: "3.8"
 
-services:
-  centos-7:
-    build:
-      context: ..
-      dockerfile: docker/centos/7/Dockerfile
+x-mod_tile:
+  build_defaults: &build_defaults
+    context: ..
+  build_defaults_centos_stream: &build_defaults_centos_stream
+    <<: *build_defaults
+    dockerfile: docker/centos/stream/Dockerfile
+  build_defaults_debian: &build_defaults_debian
+    <<: *build_defaults
+    dockerfile: docker/debian/Dockerfile
+  build_defaults_fedora: &build_defaults_fedora
+    <<: *build_defaults
+    dockerfile: docker/fedora/Dockerfile
+  build_defaults_opensuse: &build_defaults_opensuse
+    <<: *build_defaults
+    dockerfile: docker/opensuse/Dockerfile
+  build_defaults_ubuntu: &build_defaults_ubuntu
+    <<: *build_defaults
+    dockerfile: docker/ubuntu/Dockerfile
+  service_defaults: &service_defaults
     env_file: .env
     ports:
       - 8081:8081
+
+services:
+  centos-7:
+    <<: *service_defaults
+    build:
+      <<: *build_defaults
+      dockerfile: docker/centos/7/Dockerfile
     ulimits:
       nofile: 40000
   centos-stream-8:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_centos_stream
       args:
         centos_stream_version: "8"
         extra_repository: powertools
-      context: ..
-      dockerfile: docker/centos/stream/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   centos-stream-9:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_centos_stream
       args:
         centos_stream_version: "9"
         extra_repository: crb
-      context: ..
-      dockerfile: docker/centos/stream/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   debian-10:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_debian
       args:
         libmapnik_version: "3.0"
         debian_version: "10"
-      context: ..
-      dockerfile: docker/debian/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   debian-11:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_debian
       args:
         libmapnik_version: "3.1"
         debian_version: "11"
-      context: ..
-      dockerfile: docker/debian/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   debian-12:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_debian
       args:
         libmapnik_version: "3.1"
         debian_version: "12"
-      context: ..
-      dockerfile: docker/debian/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   debian-testing:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_debian
       args:
         libmapnik_version: "3.1"
         debian_version: testing
-      context: ..
-      dockerfile: docker/debian/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   fedora-34:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_fedora
       args:
         fedora_version: "34"
-      context: ..
-      dockerfile: docker/fedora/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   fedora-35:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_fedora
       args:
         fedora_version: "35"
-      context: ..
-      dockerfile: docker/fedora/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   fedora-36:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_fedora
       args:
         fedora_version: "36"
-      context: ..
-      dockerfile: docker/fedora/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   fedora-37:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_fedora
       args:
         fedora_version: "37"
-      context: ..
-      dockerfile: docker/fedora/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   fedora-38:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_fedora
       args:
         fedora_version: "38"
-      context: ..
-      dockerfile: docker/fedora/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   fedora-39:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_fedora
       args:
         fedora_version: "39"
-      context: ..
-      dockerfile: docker/fedora/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   fedora-rawhide:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_fedora
       args:
-        fedora_version: rawhide
-      context: ..
-      dockerfile: docker/fedora/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
+        fedora_version: "rawhide"
   opensuse-leap-15:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_opensuse
       args:
         boost_version: "1_75_0"
-        opensuse_version: leap:15
-      context: ..
-      dockerfile: docker/opensuse/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
+        opensuse_version: "leap:15"
   opensuse-tumbleweed:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_opensuse
       args:
-        opensuse_version: tumbleweed
-      context: ..
-      dockerfile: docker/opensuse/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
+        opensuse_version: "tumbleweed"
   ubuntu-20.04:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_ubuntu
       args:
         libmapnik_version: "3.0"
         ubuntu_version: "20.04"
-      context: ..
-      dockerfile: docker/ubuntu/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   ubuntu-22.04:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_ubuntu
       args:
         libmapnik_version: "3.1"
         ubuntu_version: "22.04"
-      context: ..
-      dockerfile: docker/ubuntu/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
   ubuntu-devel:
+    <<: *service_defaults
     build:
+      <<: *build_defaults_ubuntu
       args:
         libmapnik_version: "3.1"
-        ubuntu_version: devel
-      context: ..
-      dockerfile: docker/ubuntu/Dockerfile
-    env_file: .env
-    ports:
-      - 8081:8081
+        ubuntu_version: "devel"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -150,3 +150,35 @@ services:
       args:
         libmapnik_version: "3.1"
         ubuntu_version: "devel"
+  ubuntu-devel-full:
+    <<: *service_defaults
+    build:
+      <<: *build_defaults_ubuntu
+      args:
+        libmapnik_version: "3.1"
+        ubuntu_version: "devel"
+    depends_on:
+      - postgres
+    entrypoint: /entrypoint.sh
+    environment:
+      DOWNLOAD_PBF: http://download.geofabrik.de/africa/eritrea-latest.osm.pbf
+      PGDATABASE: gis
+      PGHOST: postgres
+      PGUSER: renderer
+    volumes:
+      - data:/data
+      - ./ubuntu/entrypoint.sh:/entrypoint.sh:ro
+  postgres:
+    env_file: .env
+    environment:
+      POSTGRES_DB: gis
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_USER: renderer
+    image: postgis/postgis
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    shm_size: 1gb
+
+volumes:
+  data:
+  pgdata:

--- a/docker/ubuntu/entrypoint.sh
+++ b/docker/ubuntu/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+
+if [ ! -f /data/style/mapnik.xml ]
+then
+    export DEBIAN_FRONTEND=noninteractive
+
+    apt-get --yes update
+
+    apt-get --no-install-recommends --yes install \
+        curl \
+        gdal-bin \
+        git \
+        node-carto \
+        osm2pgsql \
+        postgresql-client \
+        python3-yaml \
+        unzip
+
+    git clone https://github.com/gravitystorm/openstreetmap-carto.git --depth 1 /data/style
+
+    cd /data/style
+
+    python3 ./scripts/get-external-data.py -c /data/style/external-data.yml -D /data/style/data
+
+    ./scripts/get-fonts.sh
+
+    mv fonts/* /usr/share/fonts/
+
+    psql --host "${PGHOST}" --user "${PGUSER}" --dbname "${PGDATABASE}" --command "CREATE EXTENSION postgis;"
+    psql --host "${PGHOST}" --user "${PGUSER}" --dbname "${PGDATABASE}" --command "CREATE EXTENSION hstore;"
+    psql --host "${PGHOST}" --user "${PGUSER}" --dbname "${PGDATABASE}" --command "ALTER TABLE geometry_columns OWNER TO ${PGUSER};"
+    psql --host "${PGHOST}" --user "${PGUSER}" --dbname "${PGDATABASE}" --command "ALTER TABLE spatial_ref_sys OWNER TO ${PGUSER};"
+
+    curl --location "${DOWNLOAD_PBF:-http://download.geofabrik.de/asia/vietnam-latest.osm.pbf}" --output /data/region.osm.pbf
+
+    osm2pgsql --host "${PGHOST}" --username "${PGUSER}" --database "${PGDATABASE}" --create --slim -G --hstore \
+        --tag-transform-script /data/style/openstreetmap-carto.lua \
+        --number-processes "$(nproc)" \
+        -S /data/style/openstreetmap-carto.style \
+        /data/region.osm.pbf
+
+    psql --host "${PGHOST}" --user "${PGUSER}" --dbname "${PGDATABASE}" --file /data/style/indexes.sql
+
+    carto /data/style/project.mml > /data/style/mapnik.xml
+    sed -i 's#/usr/share/renderd/example-map/mapnik.xml#/data/style/mapnik.xml#g' /etc/renderd.conf
+    sed -i 's/URI=/MAXZOOM=20\nMINZOOM=0\URI=/g' /etc/renderd.conf
+    sed -i 's/maxZoom: 12/maxZoom: 20/g' /usr/share/renderd/example-map/index.html
+fi
+
+apachectl -e debug -k start
+renderd --foreground


### PR DESCRIPTION
By taking advantage of `YAML anchors`: https://docs.docker.com/compose/compose-file/10-fragments/

_Also_:
- Added `full` service to `docker/docker-compose.yml` (including real osm data and openstreetmap carto)
  - Under `ubuntu-devel-full`
    - I.E. (`cd docker && docker compose up ubuntu-devel-full`)
  - In order to more fully test