### PR TITLE
Allow custom host specification with CTest

### DIFF
--- a/.github/actions/dependencies/install/action.yml
+++ b/.github/actions/dependencies/install/action.yml
@@ -32,6 +32,8 @@ inputs:
     default: >-
       apache2
       jq
+      lcov
+      memcached
   fedora-build-dependencies:
     default: >-
       cairo-devel
@@ -47,6 +49,8 @@ inputs:
     default: >-
       httpd
       jq
+      lcov
+      memcached
   freebsd-build-dependencies:
     default: >-
       apache24
@@ -61,6 +65,8 @@ inputs:
   freebsd-test-dependencies:
     default: >-
       jq
+      lcov
+      memcached
   macos-build-dependencies:
     default: >-
       apr
@@ -76,6 +82,8 @@ inputs:
     default: >-
       coreutils
       jq
+      lcov
+      memcached
   opensuse-build-dependencies:
     default: >-
       apache2-devel
@@ -92,6 +100,8 @@ inputs:
       apache2-event
       apache2-prefork
       jq
+      lcov
+      memcached
   opensuse-mapnik-build-dependencies:
     default: >-
       bzip2
@@ -129,6 +139,8 @@ inputs:
     default: >-
       httpd
       jq
+      lcov
+      memcached
   rhel-mapnik-build-dependencies:
     default: >-
       boost-devel
@@ -181,6 +193,8 @@ inputs:
     default: >-
       apache2
       jq
+      lcov
+      memcached
   mapnik-build-version-centos-stream:
     default: 3.1.0
   mapnik-build-version-amazonlinux2-centos7:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -176,6 +176,7 @@ jobs:
     continue-on-error: true
     env:
       BUILD_PARALLEL_LEVEL: 2
+      CTEST_HOST: localhost
       LIBRARY_PATH: /usr/local/lib
       TMPDIR: /tmp
     name: >-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,15 @@ find_program(MKDIR_EXECUTABLE NAMES mkdir REQUIRED)
 find_program(SHA256SUM_EXECUTABLE NAMES gsha256sum sha256sum REQUIRED)
 find_program(TOUCH_EXECUTABLE NAMES gtouch touch REQUIRED)
 
+# Sets the host to be used for CTest test services
+if(DEFINED ENV{CTEST_HOST})
+  # To the value of environment variable "CTEST_HOST"
+  set(CTEST_HOST "$ENV{CTEST_HOST}")
+else()
+  # Or to 0.0.0.0 by default
+  set(CTEST_HOST "0.0.0.0")
+endif()
+
 #-----------------------------------------------------------------------------
 #
 #  Test configurations
@@ -37,13 +46,13 @@ find_program(TOUCH_EXECUTABLE NAMES gtouch touch REQUIRED)
 #-----------------------------------------------------------------------------
 
 set(DEFAULT_MAP_NAME "default")
-set(HTTPD0_HOST "localhost")
+set(HTTPD0_HOST "${CTEST_HOST}")
 set(HTTPD0_PORT_BASE "59000")
-set(HTTPD1_HOST "localhost")
+set(HTTPD1_HOST "${CTEST_HOST}")
 set(HTTPD1_PORT_BASE "59100")
-set(MEMCACHED_HOST "localhost")
+set(MEMCACHED_HOST "${CTEST_HOST}")
 set(MEMCACHED_PORT_BASE "60000")
-set(RENDERD1_HOST "localhost")
+set(RENDERD1_HOST "${CTEST_HOST}")
 set(RENDERD1_PORT_BASE "59500")
 
 set(CURL_CMD "${CURL_EXECUTABLE} --fail --silent")


### PR DESCRIPTION
* To facilitate running `memcached` tests for all jobs
  * `CentOS`/`Debian`/`Fedora` jobs don't seem to like running `memcached` on `localhost`
  * `FreeBSD` jobs don't seem to like running `memcached` on `0.0.0.0`