### PR TITLE
Address compiler warnings

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -116,7 +116,6 @@ jobs:
 
   macOS:
     env:
-      CFLAGS: -Wno-implicit-function-declaration
       LDFLAGS: -undefined dynamic_lookup
       LIBRARY_PATH: /usr/local/lib
       TEST_PARALLEL_LEVEL: 1

--- a/includes/config.h.in
+++ b/includes/config.h.in
@@ -1,3 +1,5 @@
+#ifndef CONFIG_H
+#define CONFIG_H
 /* Define to 1 if you have the functions. */
 #cmakedefine HAVE_DAEMON @HAVE_DAEMON@
 #cmakedefine HAVE_GETLOADAVG @HAVE_GETLOADAVG@
@@ -25,3 +27,4 @@
 
 /* Version number of project */
 #cmakedefine VERSION "@VERSION@"
+#endif

--- a/includes/g_logger.h
+++ b/includes/g_logger.h
@@ -15,8 +15,8 @@
  * along with this program; If not, see http://www.gnu.org/licenses/.
  */
 
-#ifndef GLOGGER_H
-#define GLOGGER_H
+#ifndef G_LOGGER_H
+#define G_LOGGER_H
 
 #include <glib.h>
 

--- a/includes/mod_tile.h
+++ b/includes/mod_tile.h
@@ -20,6 +20,7 @@
 
 #include "protocol.h"
 #include "store.h"
+#include <apr_tables.h>
 #include <netinet/in.h>
 
 /*Size of the delaypool hashtable*/

--- a/includes/mod_tile.h
+++ b/includes/mod_tile.h
@@ -18,6 +18,7 @@
 #ifndef MODTILE_H
 #define MODTILE_H
 
+#include "protocol.h"
 #include "store.h"
 #include <netinet/in.h>
 

--- a/includes/mod_tile.h
+++ b/includes/mod_tile.h
@@ -19,6 +19,7 @@
 #define MODTILE_H
 
 #include "store.h"
+#include <netinet/in.h>
 
 /*Size of the delaypool hashtable*/
 #define DELAY_HASHTABLE_SIZE 100057

--- a/includes/parameterize_style.hpp
+++ b/includes/parameterize_style.hpp
@@ -18,6 +18,8 @@
 #ifndef PARAMETERIZE_HPP
 #define PARAMETERIZE_HPP
 
+#include <mapnik/map.hpp>
+
 typedef void (*parameterize_function_ptr)(mapnik::Map &m, char * parameter);
 
 parameterize_function_ptr init_parameterization_function(char * function_name);

--- a/includes/request_queue.h
+++ b/includes/request_queue.h
@@ -19,6 +19,8 @@
 #define REQUEST_QUEUE_H
 
 #include "gen_tile.h"
+#include "render_config.h"
+#include <pthread.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/includes/store.h
+++ b/includes/store.h
@@ -22,9 +22,9 @@
 extern "C" {
 #endif
 
+#include "render_config.h"
 #include <stdlib.h>
 #include <sys/types.h>
-#include "render_config.h"
 
 struct stat_info {
 	off_t     size;    /* total size, in bytes */

--- a/src/cache_expire.c
+++ b/src/cache_expire.c
@@ -19,6 +19,7 @@
 #include <unistd.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -214,7 +214,7 @@ static void parameterize_map_max_connections(Map &m, int num_threads)
 		parameters params = l.datasource()->params();
 
 		if (params.find("max_size") == params.end()) {
-			sprintf(tmp, "%i", num_threads + 2);
+			snprintf(tmp, 20, "%i", num_threads + 2);
 			params["max_size"] = std::string(tmp);
 		}
 

--- a/src/gen_tile_test.cpp
+++ b/src/gen_tile_test.cpp
@@ -834,7 +834,7 @@ TEST_CASE("storage-backend", "Tile storage backend")
 	}
 
 	tile_dir = (char *) malloc(sizeof(char) * (strlen(tmp) + 15));
-	sprintf(tile_dir, "%s/mod_tile_test", tmp);
+	snprintf(tile_dir, sizeof(char) * (strlen(tmp) + 15), "%s/mod_tile_test", tmp);
 	mkdir(tile_dir, 0777);
 
 	SECTION("storage/initialise", "should return NULL") {

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -1314,35 +1314,35 @@ static int tile_handler_mod_stats(request_rec *r)
 		return error_message(r, "Failed to acquire lock, can't display stats");
 	}
 
-	ap_rprintf(r, "NoResp200: %li\n", local_stats.noResp200);
-	ap_rprintf(r, "NoResp304: %li\n", local_stats.noResp304);
-	ap_rprintf(r, "NoResp404: %li\n", local_stats.noResp404);
-	ap_rprintf(r, "NoResp503: %li\n", local_stats.noResp503);
-	ap_rprintf(r, "NoResp5XX: %li\n", local_stats.noResp5XX);
-	ap_rprintf(r, "NoRespOther: %li\n", local_stats.noRespOther);
-	ap_rprintf(r, "NoFreshCache: %li\n", local_stats.noFreshCache);
-	ap_rprintf(r, "NoOldCache: %li\n", local_stats.noOldCache);
-	ap_rprintf(r, "NoVeryOldCache: %li\n", local_stats.noVeryOldCache);
-	ap_rprintf(r, "NoFreshRender: %li\n", local_stats.noFreshRender);
-	ap_rprintf(r, "NoOldRender: %li\n", local_stats.noOldRender);
-	ap_rprintf(r, "NoVeryOldRender: %li\n", local_stats.noVeryOldRender);
+	ap_rprintf(r, "NoResp200: %" APR_UINT64_T_FMT "\n", local_stats.noResp200);
+	ap_rprintf(r, "NoResp304: %" APR_UINT64_T_FMT "\n", local_stats.noResp304);
+	ap_rprintf(r, "NoResp404: %" APR_UINT64_T_FMT "\n", local_stats.noResp404);
+	ap_rprintf(r, "NoResp503: %" APR_UINT64_T_FMT "\n", local_stats.noResp503);
+	ap_rprintf(r, "NoResp5XX: %" APR_UINT64_T_FMT "\n", local_stats.noResp5XX);
+	ap_rprintf(r, "NoRespOther: %" APR_UINT64_T_FMT "\n", local_stats.noRespOther);
+	ap_rprintf(r, "NoFreshCache: %" APR_UINT64_T_FMT "\n", local_stats.noFreshCache);
+	ap_rprintf(r, "NoOldCache: %" APR_UINT64_T_FMT "\n", local_stats.noOldCache);
+	ap_rprintf(r, "NoVeryOldCache: %" APR_UINT64_T_FMT "\n", local_stats.noVeryOldCache);
+	ap_rprintf(r, "NoFreshRender: %" APR_UINT64_T_FMT "\n", local_stats.noFreshRender);
+	ap_rprintf(r, "NoOldRender: %" APR_UINT64_T_FMT "\n", local_stats.noOldRender);
+	ap_rprintf(r, "NoVeryOldRender: %" APR_UINT64_T_FMT "\n", local_stats.noVeryOldRender);
 
 	for (i = 0; i <= global_max_zoom; i++) {
-		ap_rprintf(r, "NoRespZoom%02i: %li\n", i, local_stats.noRespZoom[i]);
+		ap_rprintf(r, "NoRespZoom%02i: %" APR_UINT64_T_FMT "\n", i, local_stats.noRespZoom[i]);
 	}
 
-	ap_rprintf(r, "NoTileBufferReads: %li\n", local_stats.noTotalBufferRetrieval);
-	ap_rprintf(r, "DurationTileBufferReads: %li\n", local_stats.totalBufferRetrievalTime);
+	ap_rprintf(r, "NoTileBufferReads: %" APR_UINT64_T_FMT "\n", local_stats.noTotalBufferRetrieval);
+	ap_rprintf(r, "DurationTileBufferReads: %" APR_UINT64_T_FMT "\n", local_stats.totalBufferRetrievalTime);
 
 	for (i = 0; i <= global_max_zoom; i++) {
-		ap_rprintf(r, "NoTileBufferReadZoom%02i: %li\n", i, local_stats.noZoomBufferRetrieval[i]);
-		ap_rprintf(r, "DurationTileBufferReadZoom%02i: %li\n", i, local_stats.zoomBufferRetrievalTime[i]);
+		ap_rprintf(r, "NoTileBufferReadZoom%02i: %" APR_UINT64_T_FMT "\n", i, local_stats.noZoomBufferRetrieval[i]);
+		ap_rprintf(r, "DurationTileBufferReadZoom%02i: %" APR_UINT64_T_FMT "\n", i, local_stats.zoomBufferRetrievalTime[i]);
 	}
 
 	for (i = 0; i < scfg->configs->nelts; ++i) {
 		tile_config_rec *tile_config = &tile_configs[i];
-		ap_rprintf(r, "NoRes200Layer%s: %li\n", tile_config->baseuri, local_stats.noResp200Layer[i]);
-		ap_rprintf(r, "NoRes404Layer%s: %li\n", tile_config->baseuri, local_stats.noResp404Layer[i]);
+		ap_rprintf(r, "NoRes200Layer%s: %" APR_UINT64_T_FMT "\n", tile_config->baseuri, local_stats.noResp200Layer[i]);
+		ap_rprintf(r, "NoRes404Layer%s: %" APR_UINT64_T_FMT "\n", tile_config->baseuri, local_stats.noResp404Layer[i]);
 	}
 
 	free(local_stats.noResp200Layer);
@@ -1388,27 +1388,27 @@ static int tile_handler_metrics(request_rec *r)
 
 	ap_rprintf(r, "# HELP modtile_http_responses_total Number of HTTP responses by response code\n");
 	ap_rprintf(r, "# TYPE modtile_http_responses_total counter\n");
-	ap_rprintf(r, "modtile_http_responses_total{status=\"200\"} %li\n", local_stats.noResp200);
-	ap_rprintf(r, "modtile_http_responses_total{status=\"304\"} %li\n", local_stats.noResp304);
-	ap_rprintf(r, "modtile_http_responses_total{status=\"404\"} %li\n", local_stats.noResp404);
-	ap_rprintf(r, "modtile_http_responses_total{status=\"503\"} %li\n", local_stats.noResp503);
-	ap_rprintf(r, "modtile_http_responses_total{status=\"5XX\"} %li\n", local_stats.noResp5XX);
-	ap_rprintf(r, "modtile_http_responses_total{status=\"other\"} %li\n", local_stats.noRespOther);
+	ap_rprintf(r, "modtile_http_responses_total{status=\"200\"} %" APR_UINT64_T_FMT "\n", local_stats.noResp200);
+	ap_rprintf(r, "modtile_http_responses_total{status=\"304\"} %" APR_UINT64_T_FMT "\n", local_stats.noResp304);
+	ap_rprintf(r, "modtile_http_responses_total{status=\"404\"} %" APR_UINT64_T_FMT "\n", local_stats.noResp404);
+	ap_rprintf(r, "modtile_http_responses_total{status=\"503\"} %" APR_UINT64_T_FMT "\n", local_stats.noResp503);
+	ap_rprintf(r, "modtile_http_responses_total{status=\"5XX\"} %" APR_UINT64_T_FMT "\n", local_stats.noResp5XX);
+	ap_rprintf(r, "modtile_http_responses_total{status=\"other\"} %" APR_UINT64_T_FMT "\n", local_stats.noRespOther);
 
 	ap_rprintf(r, "# HELP modtile_tiles_total Tiles served\n");
 	ap_rprintf(r, "# TYPE modtile_tiles_total counter\n");
-	ap_rprintf(r, "modtile_tiles_total{age=\"fresh\",rendered=\"no\"} %li\n", local_stats.noFreshCache);
-	ap_rprintf(r, "modtile_tiles_total{age=\"old\",rendered=\"no\"} %li\n", local_stats.noOldCache);
-	ap_rprintf(r, "modtile_tiles_total{age=\"outdated\",rendered=\"no\"} %li\n", local_stats.noVeryOldCache);
-	ap_rprintf(r, "modtile_tiles_total{age=\"fresh\",rendered=\"yes\"} %li\n", local_stats.noFreshRender);
-	ap_rprintf(r, "modtile_tiles_total{age=\"old\",rendered=\"attempted\"} %li\n", local_stats.noOldRender);
-	ap_rprintf(r, "modtile_tiles_total{age=\"outdated\",rendered=\"attempted\"} %li\n", local_stats.noVeryOldRender);
+	ap_rprintf(r, "modtile_tiles_total{age=\"fresh\",rendered=\"no\"} %" APR_UINT64_T_FMT "\n", local_stats.noFreshCache);
+	ap_rprintf(r, "modtile_tiles_total{age=\"old\",rendered=\"no\"} %" APR_UINT64_T_FMT "\n", local_stats.noOldCache);
+	ap_rprintf(r, "modtile_tiles_total{age=\"outdated\",rendered=\"no\"} %" APR_UINT64_T_FMT "\n", local_stats.noVeryOldCache);
+	ap_rprintf(r, "modtile_tiles_total{age=\"fresh\",rendered=\"yes\"} %" APR_UINT64_T_FMT "\n", local_stats.noFreshRender);
+	ap_rprintf(r, "modtile_tiles_total{age=\"old\",rendered=\"attempted\"} %" APR_UINT64_T_FMT "\n", local_stats.noOldRender);
+	ap_rprintf(r, "modtile_tiles_total{age=\"outdated\",rendered=\"attempted\"} %" APR_UINT64_T_FMT "\n", local_stats.noVeryOldRender);
 
 	ap_rprintf(r, "# HELP modtile_zoom_responses_total Tiles served by zoom level\n");
 	ap_rprintf(r, "# TYPE modtile_zoom_responses_total counter\n");
 
 	for (i = 0; i <= global_max_zoom; i++) {
-		ap_rprintf(r, "modtile_zoom_responses_total{zoom=\"%02i\"} %li\n", i, local_stats.noRespZoom[i]);
+		ap_rprintf(r, "modtile_zoom_responses_total{zoom=\"%02i\"} %" APR_UINT64_T_FMT "\n", i, local_stats.noRespZoom[i]);
 	}
 
 
@@ -1416,7 +1416,7 @@ static int tile_handler_metrics(request_rec *r)
 	ap_rprintf(r, "# TYPE modtile_tile_reads_total counter\n");
 
 	for (i = 0; i <= global_max_zoom; i++) {
-		ap_rprintf(r, "modtile_tile_reads_total{zoom=\"%02i\"} %li\n", i, local_stats.noZoomBufferRetrieval[i]);
+		ap_rprintf(r, "modtile_tile_reads_total{zoom=\"%02i\"} %" APR_UINT64_T_FMT "\n", i, local_stats.noZoomBufferRetrieval[i]);
 	}
 
 	ap_rprintf(r, "# HELP modtile_tile_reads_seconds_total Tile buffer duration\n");
@@ -1431,8 +1431,8 @@ static int tile_handler_metrics(request_rec *r)
 
 	for (i = 0; i < scfg->configs->nelts; ++i) {
 		tile_config_rec *tile_config = &tile_configs[i];
-		ap_rprintf(r, "modtile_layer_responses_total{layer=\"%s\",status=\"200\"} %li\n", tile_config->baseuri, local_stats.noResp200Layer[i]);
-		ap_rprintf(r, "modtile_layer_responses_total{layer=\"%s\",status=\"404\"} %li\n", tile_config->baseuri, local_stats.noResp404Layer[i]);
+		ap_rprintf(r, "modtile_layer_responses_total{layer=\"%s\",status=\"200\"} %" APR_UINT64_T_FMT "\n", tile_config->baseuri, local_stats.noResp200Layer[i]);
+		ap_rprintf(r, "modtile_layer_responses_total{layer=\"%s\",status=\"404\"} %" APR_UINT64_T_FMT "\n", tile_config->baseuri, local_stats.noResp404Layer[i]);
 	}
 
 	free(local_stats.noResp200Layer);

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -449,7 +449,7 @@ static enum tileState tile_state(request_rec *r, struct protocol *cmd)
 
 	stat = rdata->store->tile_stat(rdata->store, cmd->xmlname, cmd->options, cmd->x, cmd->y, cmd->z);
 
-	ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "tile_state: determined state of %s %i %i %i on store %pp: Tile size: %li, expired: %i created: %li",
+	ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "tile_state: determined state of %s %i %i %i on store %pp: Tile size: %" APR_OFF_T_FMT ", expired: %i created: %li",
 		      cmd->xmlname, cmd->x, cmd->y, cmd->z, rdata->store, stat.size, stat.expired, stat.mtime);
 
 	r->finfo.mtime = stat.mtime * 1000000;

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -589,8 +589,7 @@ static void add_expiry(request_rec *r, struct protocol * cmd)
 	ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "Setting tiles maxAge to %ld\n", maxAge);
 
 	apr_table_mergen(t, "Cache-Control",
-			 apr_psprintf(r->pool, "max-age=%" APR_TIME_T_FMT,
-				      maxAge));
+			 apr_psprintf(r->pool, "max-age=%li", maxAge));
 	timestr = apr_palloc(r->pool, APR_RFC822_DATE_LEN);
 	apr_rfc822_date(timestr, (apr_time_from_sec(maxAge) + r->request_time));
 	apr_table_setn(t, "Expires", timestr);
@@ -1267,8 +1266,7 @@ static int tile_handler_json(request_rec *r)
 	ap_set_content_type(r, "application/json");
 	ap_set_content_length(r, len);
 	apr_table_mergen(t, "Cache-Control",
-			 apr_psprintf(r->pool, "max-age=%" APR_TIME_T_FMT,
-				      maxAge));
+			 apr_psprintf(r->pool, "max-age=%li", maxAge));
 	timestr = apr_palloc(r->pool, APR_RFC822_DATE_LEN);
 	apr_rfc822_date(timestr, (apr_time_from_sec(maxAge) + r->request_time));
 	apr_table_setn(t, "Expires", timestr);

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -546,7 +546,7 @@ static void add_expiry(request_rec *r, struct protocol * cmd)
 
 		/* Test if the tile we are serving is out of date, then set a low maxAge*/
 		if (state == tileOld) {
-			holdoff = (scfg->cache_duration_dirty / 2) * (rand() / (RAND_MAX
+			holdoff = (scfg->cache_duration_dirty / 2.0) * (rand() / (RAND_MAX
 					+ 1.0));
 			maxAge = scfg->cache_duration_dirty + holdoff;
 		} else {

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -397,7 +397,7 @@ static struct storage_backend * get_storage_backend(request_rec *r, int tile_lay
 	apr_os_thread_t os_thread = apr_os_thread_current();
 
 	ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "get_storage_backend: Retrieving storage back end for tile layer %i in pool %pp and thread %li",
-		      tile_layer, lifecycle_pool, os_thread);
+		      tile_layer, lifecycle_pool, (unsigned long) os_thread);
 
 	/* In Apache 2.2, we are using the process memory pool, but with mpm_event and mpm_worker, each process has multiple threads.
 	 * As apache's memory pool operations are not thread-safe, we need to wrap everything into a mutex to protect against
@@ -411,7 +411,7 @@ static struct storage_backend * get_storage_backend(request_rec *r, int tile_lay
 	}
 
 	if (stores == NULL) {
-		ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "get_storage_backend: No storage backends for this lifecycle %pp, creating it in thread %li", lifecycle_pool, os_thread);
+		ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "get_storage_backend: No storage backends for this lifecycle %pp, creating it in thread %li", lifecycle_pool, (unsigned long) os_thread);
 		stores = apr_pcalloc(lifecycle_pool, sizeof(struct storage_backends));
 		stores->stores = apr_pcalloc(lifecycle_pool, sizeof(struct storage_backend *) * scfg->configs->nelts);
 		stores->noBackends = scfg->configs->nelts;
@@ -420,7 +420,7 @@ static struct storage_backend * get_storage_backend(request_rec *r, int tile_lay
 			ap_log_rerror(APLOG_MARK, APLOG_ERR, 0, r, "get_storage_backend: Failed horribly to set user_data!");
 		}
 	} else {
-		ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "get_storage_backend: Found backends (%pp) for this lifecycle %pp in thread %li", stores, lifecycle_pool, os_thread);
+		ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "get_storage_backend: Found backends (%pp) for this lifecycle %pp in thread %li", stores, lifecycle_pool, (unsigned long) os_thread);
 	}
 
 #ifndef APACHE24
@@ -429,11 +429,11 @@ static struct storage_backend * get_storage_backend(request_rec *r, int tile_lay
 
 	if (stores->stores[tile_layer] == NULL) {
 		ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "get_storage_backend: No storage backend in current lifecycle %pp in thread %li for current tile layer %i",
-			      lifecycle_pool, os_thread, tile_layer);
+			      lifecycle_pool, (unsigned long) os_thread, tile_layer);
 		stores->stores[tile_layer] = init_storage_backend(tile_config->store);
 	} else {
 		ap_log_rerror(APLOG_MARK, APLOG_DEBUG, 0, r, "get_storage_backend: Storage backend found in current lifecycle %pp for current tile layer %i in thread %li",
-			      lifecycle_pool, tile_layer, os_thread);
+			      lifecycle_pool, tile_layer, (unsigned long) os_thread);
 	}
 
 	return stores->stores[tile_layer];

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -156,7 +156,7 @@ static int socket_init(request_rec *r)
 		hints.ai_canonname = NULL;
 		hints.ai_addr = NULL;
 		hints.ai_next = NULL;
-		sprintf(portnum, "%i", scfg->renderd_socket_port);
+		snprintf(portnum, 16, "%i", scfg->renderd_socket_port);
 
 		s = getaddrinfo(scfg->renderd_socket_name, portnum, &hints, &result);
 

--- a/src/render_submit_queue.c
+++ b/src/render_submit_queue.c
@@ -23,6 +23,8 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <strings.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <sys/types.h>

--- a/src/render_submit_queue.c
+++ b/src/render_submit_queue.c
@@ -430,7 +430,7 @@ void print_statistics(void)
 		}
 
 		printf("Zoom %02i: min: %4.1f    avg: %4.1f     max: %4.1f     over a total of %8.1fs in %i requests\n",
-		       i, performance_stats.stat[i].time_min / 1000.0, (performance_stats.stat[i].time_total /  performance_stats.stat[i].noRendered) / 1000.0,
+		       i, performance_stats.stat[i].time_min / 1000.0, (performance_stats.stat[i].time_total / (float) performance_stats.stat[i].noRendered) / 1000.0,
 		       performance_stats.stat[i].time_max / 1000.0, performance_stats.stat[i].time_total / 1000.0, performance_stats.stat[i].noRendered);
 	}
 

--- a/src/renderd.c
+++ b/src/renderd.c
@@ -1031,9 +1031,9 @@ int main(int argc, char **argv)
 			snprintf(buffer, sizeof(buffer), "%s:type", name);
 			const char *ini_type = iniparser_getstring(ini, buffer, "png image/png png256");
 
-			const char ini_fileExtension[INILINE_MAX] = "png";
-			const char ini_mimeType[INILINE_MAX] = "image/png";
-			const char ini_outputFormat[INILINE_MAX] = "png256";
+			char ini_fileExtension[INILINE_MAX] = "png";
+			char ini_mimeType[INILINE_MAX] = "image/png";
+			char ini_outputFormat[INILINE_MAX] = "png256";
 
 			sscanf(ini_type, "%[^ ] %[^ ] %[^;#]", ini_fileExtension, ini_mimeType, ini_outputFormat);
 

--- a/src/renderd.c
+++ b/src/renderd.c
@@ -417,7 +417,7 @@ int client_socket_init(renderd_config * sConfig)
 		hints.ai_canonname = NULL;
 		hints.ai_addr = NULL;
 		hints.ai_next = NULL;
-		sprintf(portnum, "%i", sConfig->ipport);
+		snprintf(portnum, 16, "%i", sConfig->ipport);
 
 		s = getaddrinfo(sConfig->iphostname, portnum, &hints, &result);
 

--- a/src/request_queue.c
+++ b/src/request_queue.c
@@ -394,6 +394,9 @@ void request_queue_remove_request(struct request_queue * queue, struct item * re
 				queue->stats.timeReqBulkRender += render_time;
 				break;
 			}
+
+			default:
+				break;
 		}
 
 		queue->stats.noZoomRender[request->req.z]++;
@@ -430,6 +433,9 @@ int request_queue_no_requests_queued(struct request_queue * queue, enum protoCmd
 
 		case cmdRenderBulk:
 			noReq = queue->reqBulkNum;
+			break;
+
+		default:
 			break;
 	}
 

--- a/src/store_file.c
+++ b/src/store_file.c
@@ -219,7 +219,7 @@ static int file_metatile_write(struct storage_backend * store, const char *xmlco
 	g_logger(G_LOG_LEVEL_DEBUG, "Creating and writing a metatile to %s", meta_path);
 
 	tmp = malloc(sizeof(char) * strlen(meta_path) + 24);
-	snprintf(tmp, strlen(meta_path) + 24, "%s.%lu", meta_path, pthread_self());
+	snprintf(tmp, strlen(meta_path) + 24, "%s.%lu", meta_path, (unsigned long) pthread_self());
 
 	if (mkdirp(tmp)) {
 		free(tmp);


### PR DESCRIPTION
* `includes/config.h.in`
  * Wrap contents in `#ifndef CONFIG_H`
* `includes/mod_tile.h`
  * Include `protocol.h`
    * For `XMLCONFIG_MAX`
  * Include `apr_tables.h`
    * For `apr_array_header_t`/`apr_time_t`/`apr_uint64_t`
  * Include `netinet/in.h`
    * For `in6_addr`/`in_addr_t`
* `src/cache_expire.c`
  * Include `netinet/in.h`
    * For `htonl`/`htons`
* `src/gen_tile.cpp`
  * Use `snprintf` instead of `sprintf`
    * To resolve `warning: 'sprintf' is deprecated` in [`macOS` builds](https://github.com/openstreetmap/mod_tile/actions/runs/7590268635/job/20677236621#step:5:579)
* `src/gen_tile_test.cpp`
  * Use `snprintf` instead of `sprintf`
    * To resolve `warning: 'sprintf' is deprecated` in [`macOS` builds](https://github.com/openstreetmap/mod_tile/actions/runs/7590268635/job/20677236621#step:5:579)
* `src/mod_tile.c`
  * Use `snprintf` instead of `sprintf`
    * To resolve `warning: 'sprintf' is deprecated` in [`macOS` builds](https://github.com/openstreetmap/mod_tile/actions/runs/7590268635/job/20677236621#step:5:579)
  * Cast `os_thread` to `(unsigned long)` in `ap_log_rerror` calls format
    * To resolve `warning: format specifies type 'long' but the argument has type 'apr_os_thread_t'`
    * `os_thread` is an alias of `unsigned long`
  * Use `"%" APR_OFF_T_FMT`/`APR_UINT64_T_FMT "..."` to resolve warnings under `macOS`
    * To resolve `warning: format specifies type 'long' but the argument has type 'off_t'`
      * The format/type for `apr_off_t` varies under `macOS`
        * See [here](https://github.com/apache/apr/blob/8e68a77f6110462ea8d2fd7f2003f7d09997a074/include/apr.h.in#L610-L645)
    * And resolve `warning: format specifies type 'long' but the argument has type 'apr_uint64_t'`
      * The format/type for `apr_uint64_t` varies under `macOS` 
        * See [here](https://github.com/apache/apr/blob/8e68a77f6110462ea8d2fd7f2003f7d09997a074/include/apr.h.in#L610-L645)
  * Divide by `2.0` rather than `2`
    * To resolve `possible loss of precision` warning
  * Use `%li` rather than `"%" APR_TIME_T_FMT` as format for `maxAge`
    * It is defined as a `long int`
* `src/render_submit_queue.c`
  * Include `string.h`/`strings.h`
    * To resolve `warning: call to undeclared library function 'bzero'`
    * To resolve `warning: call to undeclared library function 'strncpy'`
    * To resolve `warning: call to undeclared library function 'strdup'`
    * To resolve `warning: call to undeclared library function 'strerror'`
    * To resolve `warning: call to undeclared library function 'strchr'`
    * To resolve `warning: call to undeclared library function 'strlen'`
    * To resolve `warning: call to undeclared library function 'memset'`
  * Cast `performance_stats.stat[i].noRendered` to `(float)`
    * To resolve `possible loss of precision` warning
* `src/renderd.c`
  * Use `snprintf` instead of `sprintf`
    * To resolve `warning: 'sprintf' is deprecated` in [`macOS` builds](https://github.com/openstreetmap/mod_tile/actions/runs/7590268635/job/20677236621#step:5:579)
  * Change `const char` to `char` for `ini_fileExtension`, `ini_mimeType`, `ini_outputFormat`
    * To resolve `warning: format specifies type 'char *' but the argument has type 'const char *'`
* `src/request_queue.c`
  * Add `default case` to `switch` statements
    * To resolve:
      * `warning: enumeration values 'queueRender' and 'queueDuplicate' not handled in switch`
      * `warning: enumeration values 'cmdIgnore', 'cmdDone', and 'cmdNotDone' not handled in switch`
* `src/store_file.c`
  * Cast `pthread_self()` to `(unsigned long)`
    * To resolve `warning: format specifies type 'unsigned long' but the argument has type 'pthread_t'`
* No longer need `CFLAGS=-Wno-implicit-function-declaration` 