### PR TITLE
Move `foreground` definition into `src/g_logger.c`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -191,12 +191,10 @@ jobs:
   FreeBSD:
     continue-on-error: true
     env:
-      BUILD_PARALLEL_LEVEL: 2
       CFLAGS: --coverage
       CTEST_HOST: localhost
       CXXFLAGS: --coverage
       LIBRARY_PATH: /usr/local/lib
-      TEST_PARALLEL_LEVEL: 2
       TMPDIR: /tmp
     name: >-
       ${{ matrix.box_generic }}
@@ -223,6 +221,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Set `BUILD_PARALLEL_LEVEL` & `TEST_PARALLEL_LEVEL`
+        run: |
+          echo "BUILD_PARALLEL_LEVEL=$(nproc)" >> "$GITHUB_ENV"
+          echo "TEST_PARALLEL_LEVEL=$(nproc)" >> "$GITHUB_ENV"
 
       - name: Provision VM
         uses: hummeltech/freebsd-vagrant-action@v1.4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ find_package(Threads REQUIRED)
 
 find_package(APR REQUIRED)
 find_package(CAIRO REQUIRED)
-find_package(GLIB REQUIRED)
+find_package(GLIB 2.50 REQUIRED)
 find_package(HTTPD REQUIRED)
 find_package(INIPARSER REQUIRED)
 find_package(LIBMAPNIK 3 REQUIRED)

--- a/includes/g_logger.h
+++ b/includes/g_logger.h
@@ -24,6 +24,8 @@
 extern "C" {
 #endif
 
+extern int foreground;
+
 void g_logger(int log_level, const char *format, ...);
 
 const char *g_logger_level_name(int log_level);

--- a/src/g_logger.c
+++ b/src/g_logger.c
@@ -22,7 +22,7 @@
 #include <stdio.h>
 #include <syslog.h>
 
-extern int foreground;
+int foreground = 0;
 
 const char *g_logger_level_name(int log_level)
 {

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -78,8 +78,6 @@ using namespace mapnik;
 #define RENDER_SIZE (512)
 #endif
 
-extern int foreground;
-
 struct projectionconfig {
 	double bound_x0;
 	double bound_y0;

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -99,8 +99,6 @@ char *mutexfilename;
 int layerCount = 0;
 int global_max_zoom = 0;
 
-int foreground = 0;
-
 struct storage_backends {
 	struct storage_backend ** stores;
 	int noBackends;

--- a/src/render_expired.c
+++ b/src/render_expired.c
@@ -33,6 +33,7 @@
 
 #include <pthread.h>
 
+#include "g_logger.h"
 #include "protocol.h"
 #include "config.h"
 #include "render_config.h"
@@ -73,8 +74,6 @@ static int minZoom = 0;
 static int maxZoom = 18;
 static int verbose = 0;
 static int maxLoad = MAX_LOAD_OLD;
-
-int foreground = 1;
 
 void display_rate(struct timeval start, struct timeval end, int num)
 {
@@ -122,6 +121,7 @@ int main(int argc, char **argv)
 		mt >>= 1;
 	}
 
+	foreground = 1;
 
 	while (1) {
 		int option_index = 0;

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -34,6 +34,7 @@
 
 #include <pthread.h>
 
+#include "g_logger.h"
 #include "gen_tile.h"
 #include "protocol.h"
 #include "config.h"
@@ -57,8 +58,6 @@ static int minZoom = 0;
 static int maxZoom = MAX_ZOOM;
 static int verbose = 0;
 static int maxLoad = MAX_LOAD_OLD;
-
-int foreground = 1;
 
 
 void display_rate(struct timeval start, struct timeval end, int num)
@@ -117,6 +116,8 @@ int main(int argc, char **argv)
 	int force = 0;
 	struct storage_backend * store;
 	struct stat_info s;
+
+	foreground = 1;
 
 	while (1) {
 		int option_index = 0;

--- a/src/render_old.c
+++ b/src/render_old.c
@@ -35,7 +35,7 @@
 
 #include <pthread.h>
 
-
+#include "g_logger.h"
 #include "gen_tile.h"
 #include "protocol.h"
 #include "config.h"
@@ -63,8 +63,6 @@ static int num_render = 0, num_all = 0;
 static int max_load = MAX_LOAD_OLD;
 static time_t planetTime;
 static struct timeval start, end;
-
-int foreground = 1;
 
 
 
@@ -199,6 +197,8 @@ int main(int argc, char **argv)
 	int numThreads = 1;
 	int dd, mm, yy;
 	struct tm tm;
+
+	foreground = 1;
 
 	while (1) {
 		int option_index = 0;

--- a/src/render_speedtest.cpp
+++ b/src/render_speedtest.cpp
@@ -31,6 +31,7 @@
 #include <strings.h>
 #include <getopt.h>
 
+#include "g_logger.h"
 #include "gen_tile.h"
 #include "protocol.h"
 #include "config.h"
@@ -70,8 +71,6 @@ static double boundy0 = 49.7;
 static double boundx1 = 3.2;
 static double boundy1 = 58.8;
 #endif
-
-int foreground = 1;
 
 
 static double minmax(double a, double b, double c)
@@ -150,6 +149,8 @@ int main(int argc, char **argv)
 	int maxZoom = MAX_ZOOM;
 	int minZoom = 0;
 	int numThreads = 1;
+
+	foreground = 1;
 
 	while (1) {
 		int option_index = 0;

--- a/src/renderd.c
+++ b/src/renderd.c
@@ -66,8 +66,6 @@ static renderd_config config;
 
 int num_slave_threads;
 
-int foreground = 0;
-
 struct request_queue * render_request_queue;
 
 static const char *cmdStr(enum protoCmd c)

--- a/src/store.c
+++ b/src/store.c
@@ -24,8 +24,6 @@
 #include "store_null.h"
 #include "g_logger.h"
 
-extern int foreground;
-
 /**
  * In Apache 2.2, we call the init_storage_backend once per process. For mpm_worker and mpm_event multiple threads therefore use the same
  * storage context, and all storage backends need to be thread-safe in order not to cause issues with these mpm's

--- a/tests/gen_tile_test.cpp
+++ b/tests/gen_tile_test.cpp
@@ -65,9 +65,6 @@
 extern struct projectionconfig *get_projection(const char *srs);
 extern mapnik::box2d<double> tile2prjbounds(struct projectionconfig *prj, int x, int y, int z);
 
-extern int foreground;
-extern struct request_queue *render_request_queue;
-
 // mutex to guard access to the shared render request counter
 static pthread_mutex_t item_counter_lock;
 


### PR DESCRIPTION
And setting it to `0`, no longer requiring defining it everywhere except in foreground executables as needed.

_Also_:
* Require `GLib` >= `v2.50`
  * Needed for [g_log_writer_standard_streams](https://docs.gtk.org/glib/func.log_writer_standard_streams.html)
* Set FreeBSD job `BUILD_PARALLEL_LEVEL` & `TEST_PARALLEL_LEVEL` environment variables via `run`
  * Rather than hard-coding them