### PR TITLE
Minor Clean Up of includes and gen_tile.cpp

### DIFF
--- a/includes/cache_expire.h
+++ b/includes/cache_expire.h
@@ -25,9 +25,8 @@ extern "C" {
 #define HTCP_EXPIRE_CACHE 1
 #define HTCP_EXPIRE_CACHE_PORT "4827"
 
-
-void cache_expire(int sock, char * host, char * uri, int x, int y, int z);
-int init_cache_expire(char * htcphost);
+void cache_expire(int sock, const char *host, const char *uri, int x, int y, int z);
+int init_cache_expire(const char *htcphost);
 
 #ifdef __cplusplus
 }

--- a/includes/gen_tile.h
+++ b/includes/gen_tile.h
@@ -24,8 +24,14 @@
 extern "C" {
 #endif
 
-
-enum queueEnum {queueRequest, queueRequestPrio, queueRequestBulk, queueDirty, queueRender,  queueDuplicate, queueRequestLow};
+enum queueEnum { queueRequest,
+		 queueRequestPrio,
+		 queueRequestBulk,
+		 queueDirty,
+		 queueRender,
+		 queueDuplicate,
+		 queueRequestLow
+	       };
 
 struct item {
 	struct item *next;
@@ -38,11 +44,11 @@ struct item {
 	enum queueEnum originatedQueue;
 };
 
-//int render(Map &m, int x, int y, int z, const char *filename);
+// int render(Map &m, int x, int y, int z, const char *filename);
 void *render_thread(void *);
 struct item *fetch_request(void);
 void delete_request(struct item *item);
-void render_init(const char *plugins_dir, const char* font_dir, int font_recurse);
+void render_init(const char *plugins_dir, const char *font_dir, int font_recurse);
 
 #ifdef __cplusplus
 }

--- a/includes/metatile.h
+++ b/includes/metatile.h
@@ -18,8 +18,9 @@
 #ifndef METATILE_H
 #define METATILE_H
 
-#include "config.h"
 #include <stdlib.h>
+
+#include "config.h"
 #include "render_config.h"
 
 #ifdef __cplusplus
@@ -37,13 +38,12 @@ struct entry {
 
 struct meta_layout {
 	char magic[4];
-	int count; // METATILE ^ 2
-	int x, y, z; // lowest x,y of this metatile, plus z
+	int count;	      // METATILE ^ 2
+	int x, y, z;	      // lowest x,y of this metatile, plus z
 	struct entry index[]; // count entries
 	// Followed by the tile data
 	// The index offsets are measured from the start of the file
 };
-
 
 #ifdef __cplusplus
 }
@@ -56,17 +56,16 @@ public:
 	void set(int x, int y, const std::string &data);
 	const std::string get(int x, int y);
 	int xyz_to_meta_offset(int x, int y, int z);
-	void save(struct storage_backend * store);
-	void expire_tiles(int sock, char * host, char * uri);
+	void save(struct storage_backend *store);
+	void expire_tiles(int sock, const char *host, const char *uri);
+
 private:
 	int x_, y_, z_;
 	std::string xmlconfig_;
 	std::string options_;
 	std::string tile[METATILE][METATILE];
 	static const int header_size = sizeof(struct meta_layout) + (sizeof(struct entry) * (METATILE * METATILE));
-
 };
 
 #endif
 #endif
-

--- a/includes/mod_tile.h
+++ b/includes/mod_tile.h
@@ -46,7 +46,6 @@
 #define VERYOLD_RENDER 5
 #define VERYOLD 6
 
-
 /* Number of microseconds to camp out on the mutex */
 #define CAMPOUT 10
 /* Maximum number of times we camp out before giving up */
@@ -93,14 +92,14 @@ typedef struct stats_data {
 } stats_data;
 
 typedef struct {
-	const char * store;
+	const char *store;
 	char xmlname[XMLCONFIG_MAX];
 	char baseuri[PATH_MAX];
 	char fileExtension[PATH_MAX];
 	char mimeType[PATH_MAX];
-	const char * description;
-	const char * attribution;
-	const char * cors;
+	const char *description;
+	const char *attribution;
+	const char *cors;
 	char **hostnames;
 	int noHostnames;
 	int minzoom;
@@ -129,7 +128,7 @@ typedef struct {
 	int renderd_socket_port;
 	char tile_dir[PATH_MAX];
 	char cache_extended_hostname[PATH_MAX];
-	int  cache_extended_duration;
+	int cache_extended_duration;
 	int mincachetime[MAX_ZOOM_SERVER + 1];
 	int enableGlobalStats;
 	int enableTileThrottling;
@@ -144,12 +143,15 @@ typedef struct {
 } tile_server_conf;
 
 typedef struct tile_request_data {
-	struct protocol * cmd;
-	struct storage_backend * store;
+	struct protocol *cmd;
+	struct storage_backend *store;
 	int layerNumber;
 } tile_request_data;
 
-enum tileState { tileMissing, tileOld, tileVeryOld, tileCurrent };
-
+enum tileState { tileMissing,
+		 tileOld,
+		 tileVeryOld,
+		 tileCurrent
+	       };
 
 #endif

--- a/includes/protocol.h
+++ b/includes/protocol.h
@@ -47,7 +47,15 @@ extern "C" {
 #endif
 #define XMLCONFIG_MAX 41
 
-enum protoCmd { cmdIgnore, cmdRender, cmdDirty, cmdDone, cmdNotDone, cmdRenderPrio, cmdRenderBulk, cmdRenderLow };
+enum protoCmd { cmdIgnore,
+		cmdRender,
+		cmdDirty,
+		cmdDone,
+		cmdNotDone,
+		cmdRenderPrio,
+		cmdRenderBulk,
+		cmdRenderLow
+	      };
 
 struct protocol {
 	int ver;

--- a/includes/protocol_helper.h
+++ b/includes/protocol_helper.h
@@ -24,9 +24,8 @@ extern "C" {
 
 #include "protocol.h"
 
-int send_cmd(struct protocol * cmd, int fd);
-int recv_cmd(struct protocol * cmd, int fd, int block);
-
+int send_cmd(struct protocol *cmd, int fd);
+int recv_cmd(struct protocol *cmd, int fd, int block);
 
 #ifdef __cplusplus
 }

--- a/includes/render_config.h
+++ b/includes/render_config.h
@@ -33,7 +33,7 @@
 
 // TILE_PATH is where Openlayers with try to fetch the "z/x/y.png" tiles from
 // this is now only used if DIRECTORY_HASH is undefined
-//#define TILE_PATH "/var/www/html/osm_tiles2"
+// #define TILE_PATH "/var/www/html/osm_tiles2"
 
 // MAX_LOAD_OLD: if tile is out of date, don't re-render it if past this load threshold (users gets old tile)
 // (This is the default value. Can be overwritten in Apache config with ModTileMaxLoadOld.)
@@ -44,8 +44,8 @@
 // MAX_LOAD_ANY: give up serving any data if beyond this load (user gets 404 error)
 #define MAX_LOAD_ANY 100
 
-//VERYOLD_THRESHOLD: defines how old a tile needs to be (in microseconds) to get rendering priority rather than renderingLow priority
-//1000000*3600*24*365 = 31536000000000
+// VERYOLD_THRESHOLD: defines how old a tile needs to be (in microseconds) to get rendering priority rather than renderingLow priority
+// 1000000*3600*24*365 = 31536000000000
 #define VERYOLD_THRESHOLD 31536000000000
 
 // Location of osm.xml file
@@ -90,11 +90,11 @@
 #define FD_INVALID (-1)
 
 #ifndef MIN
-#define MIN(x,y) ((x)<(y)?(x):(y))
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
 #endif
 
 #ifndef MAX
-#define MAX(x,y) ((x)>(y)?(x):(y))
+#define MAX(x, y) ((x) > (y) ? (x) : (y))
 #endif
 
 #define MAX_CONNECTIONS (2048)
@@ -105,11 +105,11 @@
 // Use this to enable meta-tiles which will render NxN tiles at once
 // Note: This should be a power of 2 (2, 4, 8, 16 ...)
 #define METATILE (8)
-//#undef METATILE
+// #undef METATILE
 
-//Fallback to standard tiles if meta tile doesn't exist
-//Legacy - not needed on new installs
-//#undef METATILEFALLBACK
+// Fallback to standard tiles if meta tile doesn't exist
+// Legacy - not needed on new installs
+// #undef METATILEFALLBACK
 
 // Metatiles are much larger in size so we don't need big queues to handle large areas
 #ifdef METATILE

--- a/includes/render_submit_queue.h
+++ b/includes/render_submit_queue.h
@@ -21,7 +21,6 @@
 extern "C" {
 #endif
 
-
 void enqueue(const char *xmlname, int x, int y, int z);
 void spawn_workers(int num, const char *socketpath, int maxLoad);
 void wait_for_empty_queue(void);

--- a/includes/request_queue.h
+++ b/includes/request_queue.h
@@ -52,30 +52,26 @@ struct item_idx {
 struct request_queue {
 	int hashidxSize;
 	struct item reqHead, reqPrioHead, reqLowHead, reqBulkHead, dirtyHead, renderHead;
-	struct item_idx * item_hashidx;
+	struct item_idx *item_hashidx;
 	int reqNum, reqPrioNum, reqLowNum, reqBulkNum, dirtyNum;
 	pthread_mutex_t qLock;
 	pthread_cond_t qCond;
 	stats_struct stats;
 };
 
-
 struct request_queue *request_queue_init();
-void request_queue_close(struct request_queue * queue);
+void request_queue_close(struct request_queue *queue);
 
-struct item *request_queue_fetch_request(struct request_queue * queue);
-enum protoCmd request_queue_add_request(struct request_queue * queue, struct item * request);
+struct item *request_queue_fetch_request(struct request_queue *queue);
+enum protoCmd request_queue_add_request(struct request_queue *queue, struct item *request);
 
-void request_queue_remove_request(struct request_queue * queue, struct item * request, int render_time);
-void request_queue_clear_requests_by_fd(struct request_queue * queue, int fd);
+void request_queue_remove_request(struct request_queue *queue, struct item *request, int render_time);
+void request_queue_clear_requests_by_fd(struct request_queue *queue, int fd);
 
-int request_queue_no_requests_queued(struct request_queue * queue, enum protoCmd);
-void request_queue_copy_stats(struct request_queue * queue, stats_struct * stats);
-
+int request_queue_no_requests_queued(struct request_queue *queue, enum protoCmd);
+void request_queue_copy_stats(struct request_queue *queue, stats_struct *stats);
 
 #ifdef __cplusplus
 }
 #endif
 #endif
-
-

--- a/includes/store.h
+++ b/includes/store.h
@@ -27,26 +27,26 @@ extern "C" {
 #include <sys/types.h>
 
 struct stat_info {
-	off_t     size;    /* total size, in bytes */
-	time_t    atime;   /* time of last access */
-	time_t    mtime;   /* time of last modification */
-	time_t    ctime;   /* time of last status change */
-	int       expired;  /* has the tile expired */
+	off_t size;   /* total size, in bytes */
+	time_t atime; /* time of last access */
+	time_t mtime; /* time of last modification */
+	time_t ctime; /* time of last status change */
+	int expired;  /* has the tile expired */
 };
 
 struct storage_backend {
-	int (*tile_read)(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int * compressed, char * err_msg);
-	struct stat_info(*tile_stat)(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z);
-	int (*metatile_write)(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz);
-	int (*metatile_delete)(struct storage_backend * store, const char *xmlconfig, int x, int y, int z);
-	int (*metatile_expire)(struct storage_backend * store, const char *xmlconfig, int x, int y, int z);
-	char * (*tile_storage_id)(struct storage_backend * store, const char *xmlconfig, const char *options, int x, int y, int z, char * string);
-	int (*close_storage)(struct storage_backend * store);
+	int (*tile_read)(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char *buf, size_t sz, int *compressed, char *err_msg);
+	struct stat_info(*tile_stat)(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z);
+	int (*metatile_write)(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, const char *buf, int sz);
+	int (*metatile_delete)(struct storage_backend *store, const char *xmlconfig, int x, int y, int z);
+	int (*metatile_expire)(struct storage_backend *store, const char *xmlconfig, int x, int y, int z);
+	char *(*tile_storage_id)(struct storage_backend *store, const char *xmlconfig, const char *options, int x, int y, int z, char *string);
+	int (*close_storage)(struct storage_backend *store);
 
-	void * storage_ctx;
+	void *storage_ctx;
 };
 
-struct storage_backend * init_storage_backend(const char * options);
+struct storage_backend *init_storage_backend(const char *options);
 
 #ifdef __cplusplus
 }

--- a/includes/store_file.h
+++ b/includes/store_file.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #include "store.h"
 
-struct storage_backend * init_storage_file(const char * tile_dir);
+struct storage_backend *init_storage_file(const char *tile_dir);
 int xyzo_to_meta(char *path, size_t len, const char *tile_dir, const char *xmlconfig, const char *options, int x, int y, int z);
 
 #ifdef __cplusplus

--- a/includes/store_file_utils.h
+++ b/includes/store_file_utils.h
@@ -50,5 +50,4 @@ void xyz_to_path(char *path, size_t len, const char *tile_dir, const char *xmlco
 }
 #endif
 
-
 #endif

--- a/includes/store_memcached.h
+++ b/includes/store_memcached.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #include "store.h"
 
-struct storage_backend * init_storage_memcached(const char * connection_string);
+struct storage_backend *init_storage_memcached(const char *connection_string);
 
 #ifdef __cplusplus
 }

--- a/includes/store_null.h
+++ b/includes/store_null.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #include "store.h"
 
-struct storage_backend * init_storage_null();
+struct storage_backend *init_storage_null();
 
 #ifdef __cplusplus
 }

--- a/includes/store_rados.h
+++ b/includes/store_rados.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #include "store.h"
 
-struct storage_backend * init_storage_rados(const char * connection_string);
+struct storage_backend *init_storage_rados(const char *connection_string);
 
 #ifdef __cplusplus
 }

--- a/includes/store_ro_composite.h
+++ b/includes/store_ro_composite.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #include "store.h"
 
-struct storage_backend * init_storage_ro_composite(const char * connection_string);
+struct storage_backend *init_storage_ro_composite(const char *connection_string);
 
 #ifdef __cplusplus
 }

--- a/includes/store_ro_http_proxy.h
+++ b/includes/store_ro_http_proxy.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #include "store.h"
 
-struct storage_backend * init_storage_ro_http_proxy(const char * connection_string);
+struct storage_backend *init_storage_ro_http_proxy(const char *connection_string);
 
 #ifdef __cplusplus
 }

--- a/src/cache_expire.c
+++ b/src/cache_expire.c
@@ -15,13 +15,15 @@
  * along with this program; If not, see http://www.gnu.org/licenses/.
  */
 
-#include <string.h>
-#include <unistd.h>
-#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <glib.h>
 #include <netdb.h>
-#include <netinet/in.h>
-#include <stdlib.h>
+#include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
 #include "cache_expire.h"
 #include "g_logger.h"
@@ -108,7 +110,7 @@ static void cache_expire_url(int sock, char * url)
 	free(buf);
 }
 
-void cache_expire(int sock, char * host, char * uri, int x, int y, int z)
+void cache_expire(int sock, const char *host, const char *uri, int x, int y, int z)
 {
 
 	if (sock < 0) {
@@ -121,7 +123,7 @@ void cache_expire(int sock, char * host, char * uri, int x, int y, int z)
 	free(url);
 }
 
-int init_cache_expire(char * htcphost)
+int init_cache_expire(const char * htcphost)
 {
 	struct addrinfo hints;
 	struct addrinfo *result, *rp;

--- a/src/gen_tile.cpp
+++ b/src/gen_tile.cpp
@@ -15,61 +15,59 @@
  * along with this program; If not, see http://www.gnu.org/licenses/.
  */
 
-#include <mapnik/version.hpp>
-#include <mapnik/map.hpp>
-#include <mapnik/layer.hpp>
-#include <mapnik/datasource.hpp>
-#include <mapnik/feature_type_style.hpp>
-#include <mapnik/datasource_cache.hpp>
-#include <mapnik/agg_renderer.hpp>
-#include <mapnik/load_map.hpp>
-#include <mapnik/image_util.hpp>
-
-#include <exception>
-#include <iostream>
-#include <fstream>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/time.h>
 #include <dirent.h>
-#include <unistd.h>
+#include <exception>
+#include <glib.h>
+#include <limits.h>
+#include <map>
+#include <mapnik/agg_renderer.hpp>
+#include <mapnik/coord.hpp>
+#include <mapnik/datasource.hpp>
+#include <mapnik/datasource_cache.hpp>
+#include <mapnik/font_engine_freetype.hpp>
+#include <mapnik/image.hpp>
+#include <mapnik/image_util.hpp>
+#include <mapnik/image_view.hpp>
+#include <mapnik/image_view_any.hpp>
+#include <mapnik/layer.hpp>
+#include <mapnik/load_map.hpp>
+#include <mapnik/map.hpp>
+#include <mapnik/params.hpp>
+#include <mapnik/pixel_types.hpp>
+#include <mapnik/version.hpp>
+#include <math.h>
+#include <memory>
 #include <pthread.h>
-#include <string>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <sys/time.h>
+#include <unistd.h>
+#include <utility>
 
+#include "cache_expire.h"
+#include "g_logger.h"
 #include "gen_tile.h"
+#include "metatile.h"
+#include "parameterize_style.hpp"
+#include "protocol.h"
 #include "render_config.h"
 #include "renderd.h"
-#include "store.h"
-#include "metatile.h"
-#include "protocol.h"
 #include "request_queue.h"
-#include "cache_expire.h"
-#include "parameterize_style.hpp"
-#include "g_logger.h"
+#include "store.h"
 
-#ifdef HTCP_EXPIRE_CACHE
-#include <sys/socket.h>
-#include <netdb.h>
-#endif
-
-#define image_data_32 image_rgba8
-#define image_32 image_rgba8
-#include <mapnik/image.hpp>
-#include <mapnik/image_view_any.hpp>
 #if MAPNIK_MAJOR_VERSION >= 4
 #include <mapnik/geometry/box2d.hpp>
 #else
 #include <mapnik/box2d.hpp>
 #endif
 
-
-using namespace mapnik;
 #ifndef DEG_TO_RAD
-#define DEG_TO_RAD (M_PI/180)
+#define DEG_TO_RAD (M_PI / 180)
 #endif
 #ifndef RAD_TO_DEG
-#define RAD_TO_DEG (180/M_PI)
+#define RAD_TO_DEG (180 / M_PI)
 #endif
 
 #ifdef METATILE
@@ -78,57 +76,61 @@ using namespace mapnik;
 #define RENDER_SIZE (512)
 #endif
 
+using namespace mapnik;
+
+#define image_data_32 image_rgba8
+#define image_32 image_rgba8
+
 struct projectionconfig {
 	double bound_x0;
 	double bound_y0;
 	double bound_x1;
 	double bound_y1;
-	int    aspect_x;
-	int    aspect_y;
+	int aspect_x;
+	int aspect_y;
 };
 
 struct xmlmapconfig {
-	char xmlname[XMLCONFIG_MAX];
-	char xmlfile[PATH_MAX];
-	char output_format[XMLCONFIG_MAX];
-	struct storage_backend * store;
 	Map map;
-	struct projectionconfig * prj;
-	char xmluri[PATH_MAX];
-	char host[PATH_MAX];
-	char htcphost[PATH_MAX];
-	int htcpsock;
-	int tilesize;
+	const char *host;
+	const char *htcphost;
+	const char *output_format;
+	const char *xmlfile;
+	const char *xmlname;
+	const char *xmluri;
 	double scale;
-	int minzoom;
+	int htcpsock;
 	int maxzoom;
+	int minzoom;
 	int ok;
+	int tilesize;
 	parameterize_function_ptr parameterize_function;
-	xmlmapconfig() :
-		map(256, 256) {}
+	struct projectionconfig *prj;
+	struct storage_backend *store;
+
+	xmlmapconfig() : map(256, 256) {}
 };
 
-
-struct projectionconfig * get_projection(const char * srs)
+struct projectionconfig *get_projection(const char *srs)
 {
-	struct projectionconfig * prj;
+	struct projectionconfig *prj;
 
 	if (strstr(srs, "+proj=merc +a=6378137 +b=6378137") != NULL) {
 		g_logger(G_LOG_LEVEL_DEBUG, "Using web mercator projection settings");
 		prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
 		prj->bound_x0 = -20037508.3428;
-		prj->bound_x1 =  20037508.3428;
+		prj->bound_x1 = 20037508.3428;
 		prj->bound_y0 = -20037508.3428;
-		prj->bound_y1 =  20037508.3428;
+		prj->bound_y1 = 20037508.3428;
 		prj->aspect_x = 1;
 		prj->aspect_y = 1;
 	} else if (strcmp(srs, "+proj=eqc +lat_ts=0 +lat_0=0 +lon_0=0 +x_0=0 +y_0=0 +ellps=WGS84 +datum=WGS84 +units=m +no_defs") == 0) {
 		g_logger(G_LOG_LEVEL_DEBUG, "Using plate carree projection settings");
 		prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
 		prj->bound_x0 = -20037508.3428;
-		prj->bound_x1 =  20037508.3428;
+		prj->bound_x1 = 20037508.3428;
 		prj->bound_y0 = -10018754.1714;
-		prj->bound_y1 =  10018754.1714;
+		prj->bound_y1 = 10018754.1714;
 		prj->aspect_x = 2;
 		prj->aspect_y = 1;
 	} else if (strcmp(srs, "+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy +datum=OSGB36 +units=m +no_defs") == 0) {
@@ -144,9 +146,9 @@ struct projectionconfig * get_projection(const char * srs)
 		g_logger(G_LOG_LEVEL_WARNING, "Unknown projection string, using web mercator as never the less. %s", srs);
 		prj = (struct projectionconfig *)malloc(sizeof(struct projectionconfig));
 		prj->bound_x0 = -20037508.3428;
-		prj->bound_x1 =  20037508.3428;
+		prj->bound_x1 = 20037508.3428;
 		prj->bound_y0 = -20037508.3428;
-		prj->bound_y1 =  20037508.3428;
+		prj->bound_y1 = 20037508.3428;
 		prj->aspect_x = 1;
 		prj->aspect_y = 1;
 	}
@@ -157,45 +159,28 @@ struct projectionconfig * get_projection(const char * srs)
 static void load_fonts(const char *font_dir, int recurse)
 {
 	DIR *fonts = opendir(font_dir);
-	struct dirent *entry;
-	char path[PATH_MAX]; // FIXME: Eats lots of stack space when recursive
 
 	if (!fonts) {
 		g_logger(G_LOG_LEVEL_CRITICAL, "Unable to open font directory: %s", font_dir);
 		return;
 	}
 
-	while ((entry = readdir(fonts))) {
-		struct stat b;
-		char *p;
-
-		if (!strcmp(entry->d_name, ".") || !strcmp(entry->d_name, "..")) {
-			continue;
-		}
-
-		snprintf(path, sizeof(path), "%s/%s", font_dir, entry->d_name);
-
-		if (stat(path, &b)) {
-			continue;
-		}
-
-		if (S_ISDIR(b.st_mode)) {
-			if (recurse) {
-				load_fonts(path, recurse);
-			}
-
-			continue;
-		}
-
-		p = strrchr(path, '.');
-
-		if (p && (!strcmp(p, ".ttf") || !strcmp(p, ".otf") || !strcmp(p, ".ttc"))) {
-			g_logger(G_LOG_LEVEL_DEBUG, "Loading font: %s", path);
-			freetype_engine::register_font(path);
-		}
-	}
-
 	closedir(fonts);
+
+	g_logger(G_LOG_LEVEL_INFO, "Loading fonts%sfrom directory '%s'", recurse ? " recursively " : " ", font_dir);
+
+	freetype_engine::register_fonts(font_dir, recurse);
+
+	freetype_engine::font_file_mapping_type face_name_mappings = freetype_engine::get_mapping();
+
+	freetype_engine::font_file_mapping_type::iterator face_name_mappings_iterator = face_name_mappings.begin();
+
+	while (face_name_mappings_iterator != face_name_mappings.end()) {
+		const char *face_name = face_name_mappings_iterator->first.c_str();
+		const char *font_file_name = face_name_mappings_iterator->second.second.c_str();
+		g_logger(G_LOG_LEVEL_DEBUG, "Loaded font face '%s' from file '%s'", face_name, font_file_name);
+		face_name_mappings_iterator++;
+	}
 }
 
 /**
@@ -205,10 +190,10 @@ static void load_fonts(const char *font_dir, int recurse)
 static void parameterize_map_max_connections(Map &m, int num_threads)
 {
 	unsigned int i;
-	char * tmp = (char *)malloc(20);
+	char *tmp = (char *)malloc(20);
 
 	for (i = 0; i < m.layer_count(); i++) {
-		layer& l = m.get_layer(i);
+		layer &l = m.get_layer(i);
 		parameters params = l.datasource()->params();
 
 		if (params.find("max_size") == params.end()) {
@@ -222,8 +207,7 @@ static void parameterize_map_max_connections(Map &m, int num_threads)
 	free(tmp);
 }
 
-
-static int check_xyz(int x, int y, int z, struct xmlmapconfig * map)
+static int check_xyz(int x, int y, int z, struct xmlmapconfig *map)
 {
 	int oob, limit;
 
@@ -244,7 +228,7 @@ static int check_xyz(int x, int y, int z, struct xmlmapconfig * map)
 }
 
 #ifdef METATILE
-mapnik::box2d<double> tile2prjbounds(struct projectionconfig * prj, int x, int y, int z)
+mapnik::box2d<double> tile2prjbounds(struct projectionconfig *prj, int x, int y, int z)
 {
 
 	int render_size_tx = MIN(METATILE, prj->aspect_x * (1 << z));
@@ -258,10 +242,10 @@ mapnik::box2d<double> tile2prjbounds(struct projectionconfig * prj, int x, int y
 	g_logger(G_LOG_LEVEL_DEBUG, "Rendering projected coordinates %i %i %i -> %f|%f %f|%f to a %i x %i tile", z, x, y, p0x, p0y, p1x, p1y, render_size_tx, render_size_ty);
 
 	mapnik::box2d<double> bbox(p0x, p0y, p1x, p1y);
-	return  bbox;
+	return bbox;
 }
 
-static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char *options, metaTile &tiles)
+static enum protoCmd render(struct xmlmapconfig *map, int x, int y, int z, char *options, metaTile &tiles)
 {
 	unsigned int render_size_tx = MIN(METATILE, map->prj->aspect_x * (1 << z));
 	unsigned int render_size_ty = MIN(METATILE, map->prj->aspect_y * (1 << z));
@@ -273,7 +257,7 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char
 		map->map.set_buffer_size((map->tilesize >> 1) * map->scale);
 	}
 
-	//m.zoom(size+1);
+	// m.zoom(size+1);
 
 	mapnik::image_32 buf(render_size_tx * map->tilesize, render_size_ty * map->tilesize);
 
@@ -291,7 +275,7 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char
 			mapnik::agg_renderer<mapnik::image_32> ren(map->map, buf, map->scale);
 			ren.apply();
 		}
-	} catch (std::exception const& ex) {
+	} catch (std::exception const &ex) {
 		g_logger(G_LOG_LEVEL_ERROR, "failed to render TILE %s %d %d-%d %d-%d", map->xmlname, z, x, x + render_size_tx - 1, y, y + render_size_ty - 1);
 		g_logger(G_LOG_LEVEL_ERROR, "  reason: %s", ex.what());
 		return cmdNotDone;
@@ -310,8 +294,8 @@ static enum protoCmd render(struct xmlmapconfig * map, int x, int y, int z, char
 
 	return cmdDone; // OK
 }
-#else //METATILE
-static enum protoCmd render(Map &m, const char *tile_dir, char *xmlname, projection &prj, int x, int y, int z, char* outputFormat)
+#else  // METATILE
+static enum protoCmd render(Map &m, const char *tile_dir, char *xmlname, projection &prj, int x, int y, int z, char *outputFormat)
 {
 	char filename[PATH_MAX];
 	char tmp[PATH_MAX];
@@ -354,40 +338,38 @@ static enum protoCmd render(Map &m, const char *tile_dir, char *xmlname, project
 
 	return cmdDone; // OK
 }
-#endif //METATILE
+#endif // METATILE
 
-
-void render_init(const char *plugins_dir, const char* font_dir, int font_dir_recurse)
+void render_init(const char *plugins_dir, const char *font_dir, int font_dir_recurse)
 {
 	g_logger(G_LOG_LEVEL_INFO, "Renderd is using mapnik version %i.%i.%i", MAPNIK_MAJOR_VERSION, MAPNIK_MINOR_VERSION, MAPNIK_PATCH_VERSION);
 	mapnik::datasource_cache::instance().register_datasources(plugins_dir);
 	load_fonts(font_dir, font_dir_recurse);
 }
 
-void *render_thread(void * arg)
+void *render_thread(void *arg)
 {
-	xmlconfigitem * parentxmlconfig = (xmlconfigitem *)arg;
+	xmlconfigitem *parentxmlconfig = (xmlconfigitem *)arg;
 	xmlmapconfig maps[XMLCONFIGS_MAX];
 	int i, iMaxConfigs;
 	int render_time;
 
-	g_logger(G_LOG_LEVEL_DEBUG, "Starting rendering thread: %lu", (unsigned long) pthread_self());
+	g_logger(G_LOG_LEVEL_DEBUG, "Starting rendering thread: %lu", (unsigned long)pthread_self());
 
 	for (iMaxConfigs = 0; iMaxConfigs < XMLCONFIGS_MAX; ++iMaxConfigs) {
 		if (parentxmlconfig[iMaxConfigs].xmlname == NULL || parentxmlconfig[iMaxConfigs].xmlfile == NULL) {
 			break;
 		}
 
-		strcpy(maps[iMaxConfigs].xmlname, parentxmlconfig[iMaxConfigs].xmlname);
-		strcpy(maps[iMaxConfigs].xmlfile, parentxmlconfig[iMaxConfigs].xmlfile);
-		strcpy(maps[iMaxConfigs].output_format, parentxmlconfig[iMaxConfigs].output_format);
-		maps[iMaxConfigs].store = init_storage_backend(parentxmlconfig[iMaxConfigs].tile_dir);
-		maps[iMaxConfigs].tilesize  = parentxmlconfig[iMaxConfigs].tile_px_size;
-		maps[iMaxConfigs].scale  = parentxmlconfig[iMaxConfigs].scale_factor;
-		maps[iMaxConfigs].minzoom = parentxmlconfig[iMaxConfigs].min_zoom;
 		maps[iMaxConfigs].maxzoom = parentxmlconfig[iMaxConfigs].max_zoom;
+		maps[iMaxConfigs].minzoom = parentxmlconfig[iMaxConfigs].min_zoom;
+		maps[iMaxConfigs].output_format = strndup(parentxmlconfig[iMaxConfigs].output_format, PATH_MAX);
 		maps[iMaxConfigs].parameterize_function = init_parameterization_function(parentxmlconfig[iMaxConfigs].parameterization);
-
+		maps[iMaxConfigs].scale = parentxmlconfig[iMaxConfigs].scale_factor;
+		maps[iMaxConfigs].store = init_storage_backend(parentxmlconfig[iMaxConfigs].tile_dir);
+		maps[iMaxConfigs].tilesize = parentxmlconfig[iMaxConfigs].tile_px_size;
+		maps[iMaxConfigs].xmlfile = strndup(parentxmlconfig[iMaxConfigs].xmlfile, PATH_MAX);
+		maps[iMaxConfigs].xmlname = strndup(parentxmlconfig[iMaxConfigs].xmlname, PATH_MAX);
 
 		if (maps[iMaxConfigs].store) {
 			maps[iMaxConfigs].ok = 1;
@@ -410,7 +392,7 @@ void *render_thread(void * arg)
 				}
 
 				maps[iMaxConfigs].prj = get_projection(maps[iMaxConfigs].map.srs().c_str());
-			} catch (std::exception const& ex) {
+			} catch (std::exception const &ex) {
 				g_logger(G_LOG_LEVEL_ERROR, "An error occurred while loading the map layer '%s': %s", maps[iMaxConfigs].xmlname, ex.what());
 				maps[iMaxConfigs].ok = 0;
 			} catch (...) {
@@ -419,13 +401,12 @@ void *render_thread(void * arg)
 			}
 
 #ifdef HTCP_EXPIRE_CACHE
-			strcpy(maps[iMaxConfigs].xmluri, parentxmlconfig[iMaxConfigs].xmluri);
-			strcpy(maps[iMaxConfigs].host, parentxmlconfig[iMaxConfigs].host);
-			strcpy(maps[iMaxConfigs].htcphost, parentxmlconfig[iMaxConfigs].htcpip);
+			maps[iMaxConfigs].host = strndup(parentxmlconfig[iMaxConfigs].host, PATH_MAX);
+			maps[iMaxConfigs].htcphost = strndup(parentxmlconfig[iMaxConfigs].htcpip, PATH_MAX);
+			maps[iMaxConfigs].xmluri = strndup(parentxmlconfig[iMaxConfigs].xmluri, PATH_MAX);
 
 			if (strlen(maps[iMaxConfigs].htcphost) > 0) {
-				maps[iMaxConfigs].htcpsock = init_cache_expire(
-								     maps[iMaxConfigs].htcphost);
+				maps[iMaxConfigs].htcpsock = init_cache_expire(maps[iMaxConfigs].htcphost);
 
 				if (maps[iMaxConfigs].htcpsock > 0) {
 					g_logger(G_LOG_LEVEL_DEBUG, "Successfully opened socket for HTCP cache expiry");
@@ -436,7 +417,7 @@ void *render_thread(void * arg)
 				maps[iMaxConfigs].htcpsock = -1;
 			}
 
-#endif
+#endif // HTCP_EXPIRE_CACHE
 		} else {
 			maps[iMaxConfigs].ok = 0;
 		}
@@ -489,9 +470,9 @@ void *render_thread(void * arg)
 									tiles.save(maps[i].store);
 #ifdef HTCP_EXPIRE_CACHE
 									tiles.expire_tiles(maps[i].htcpsock, maps[i].host, maps[i].xmluri);
-#endif
+#endif // HTCP_EXPIRE_CACHE
 
-								} catch (std::exception const& ex) {
+								} catch (std::exception const &ex) {
 									g_logger(G_LOG_LEVEL_ERROR, "Received exception when writing metatile to disk: %s", ex.what());
 									ret = cmdNotDone;
 								} catch (...) {
@@ -502,12 +483,12 @@ void *render_thread(void * arg)
 								}
 							}
 
-#else //METATILE
+#else // METATILE
 			ret = render(maps[i].map, maps[i].tile_dir, req->xmlname, maps[i].prj, req->x, req->y, req->z, maps[i].output_format);
 #ifdef HTCP_EXPIRE_CACHE
 			cache_expire(maps[i].htcpsock, maps[i].host, maps[i].xmluri, req->x, req->y, req->z);
-#endif
-#endif //METATILE
+#endif // HTCP_EXPIRE_CACHE
+#endif // METATILE
 						} else {
 							g_logger(G_LOG_LEVEL_WARNING, "Received request for map layer %s is outside of acceptable bounds z(%i), x(%i), y(%i)",
 								 req->xmlname, req->z, req->x, req->y);
@@ -521,7 +502,7 @@ void *render_thread(void * arg)
 					send_response(item, ret, render_time);
 
 					if ((ret != cmdDone) && (ret != cmdIgnore)) {
-						sleep(10);        //Something went wrong with rendering, delay next processing to allow temporary issues to fix them selves
+						sleep(10); // Something went wrong with rendering, delay next processing to allow temporary issues to fix them selves
 					}
 
 					break;

--- a/src/metatile.cpp
+++ b/src/metatile.cpp
@@ -15,19 +15,18 @@
  * along with this program; If not, see http://www.gnu.org/licenses/.
  */
 
-#include "config.h"
-
-#include <string.h>
+#include <glib.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <sys/types.h>
 
-#include "render_config.h"
-#include "metatile.h"
-#include "store.h"
 #include "cache_expire.h"
-#include "request_queue.h"
 #include "g_logger.h"
-
+#include "metatile.h"
+#include "render_config.h"
+#include "store.h"
 
 metaTile::metaTile(const std::string &xmlconfig, const std::string &options, int x, int y, int z):
 	x_(x), y_(y), z_(z), xmlconfig_(xmlconfig), options_(options)
@@ -122,7 +121,7 @@ void metaTile::save(struct storage_backend * store)
 }
 
 
-void metaTile::expire_tiles(int sock, char * host, char * uri)
+void metaTile::expire_tiles(int sock, const char *host, const char *uri)
 {
 	if (sock < 0) {
 		return;


### PR DESCRIPTION
_Also_:
* Use `mapnik::freetype_engine::register_fonts` in `gen_tile.cpp` rather than recursing manually
  * Available since `Mapnik` v2 which is no longer supported