### PR TITLE
Update man pages for render_expired/render_list

### DIFF
--- a/docs/man/render_expired.1
+++ b/docs/man/render_expired.1
@@ -1,4 +1,4 @@
-.TH RENDER_EXPIRED "1" "2023-12-19" "mod_tile v0.7.0"
+.TH RENDER_EXPIRED "1" "2024-03-08" "mod_tile v0.7.0"
 .\" Please adjust this date whenever revising the manpage.
 
 .SH NAME
@@ -6,7 +6,7 @@ render_expired \- expires a list of map tiles so that they get re-rendered.
 
 .SH SYNOPSIS
 .B render_expired
-.RI [ options ] <  "expire.list"
+.RI [ options ]\ <\  "expire.list"
 .BR
 
 .SH DESCRIPTION
@@ -27,13 +27,13 @@ Render_expired has three potential strategies of how to expire map tiles:
 These three strategies can be combined and applied at different zoom levels. E.g. Zoom level 17-18 get deleted, z11 - z16 get marked dirty and z6 - z10 get rendered directly.
 .PP
 Render_expired takes a list of tiles from stdin which should be expired. The format of the list is one tile per line specified as z/x/y.
-.BR
+.sp 0
 1/0/1
-.BR
+.sp 0
 1/1/1
-.BR
+.sp 0
 1/0/0
-.BR
+.sp 0
 1/1/0
 .PP
 render_expired will automatically expand the list to cover the effected tiles at other zoom levels.
@@ -44,6 +44,21 @@ This program follows the usual GNU command line syntax, with long
 options starting with two dashes (`-').
 A summary of options is included below.
 .TP
+\fB\-c\fR|\-\-config=CONFIG
+Specify a `renderd.conf` file from which to load various option values rather than specifying via command line.
+.sp 0
+The following options will be set (if present); however, they can be overridden if also specified:
+.sp 0
+\fB\-s\fR|\-\-socket
+.sp 0
+\fB\-n\fR|\-\-num-threads
+.sp 0
+\fB\-t\fR|\-\-tile-dir
+.sp 0
+\fB\-z\fR|\-\-min-zoom
+.sp 0
+\fB\-Z\fR|\-\-max-zoom
+.TP
 \fB\-m\fR|\-\-map=MAP
 Specify the style-sheet for which to expire tiles. The default is "default".
 .TP
@@ -52,24 +67,23 @@ Specify the location of the renderd socket or hostname and port to connect to.
 .TP
 \fB\-n\fR|\-\-num-threads=N
 Specify the number of parallel requests to renderd. Should renderd have less threads active, requests will be queued. The default is 1.
-default if \fB\-\-append\fR is not specified.
 .TP
 \fB\-t\fR|\-\-tile-dir=DIR
 Specify the base directory where the rendered tiles are. The default is '/var/cache/renderd/tiles'
 .TP
 \fB\-z\fR|\-\-min-zoom=ZOOM
-Filter input to only render tiles greater or equal to this zoom level (default is 0)
+Filter input to only render tiles greater than or equal to this zoom level (default is '0').
 .TP
 \fB\-Z\fR|\-\-max-zoom=ZOOM
-Filter input to only render tiles less than or equal to this zoom level (default is 18)
+Filter input to only render tiles less than or equal to this zoom level (default is '20').
 .TP
 \fB\-d\fR|\-\-delete-from=ZOOM
 When expiring tiles of ZOOM or higher, delete them instead of re-rendering (default is off)
 .TP
 \fB\-T\fR|\-\-touch-from=ZOOM
-when expiring tiles of ZOOM or higher, touch them instead of re-rendering (default is off)
+When expiring tiles of ZOOM or higher, touch them instead of re-rendering (default is off)
 .TP
-\-\-no-progress
+\fB\-N\fR|\-\-no-progress
 Disable display of progress messages (default is off)
 .TP
 \fB\-h\fR|\-\-help

--- a/docs/man/render_list.1
+++ b/docs/man/render_list.1
@@ -1,4 +1,4 @@
-.TH RENDER_LIST "1" "2024-02-06" "mod_tile v0.7.0"
+.TH RENDER_LIST "1" "2024-03-08" "mod_tile v0.7.0"
 .\" Please adjust this date whenever revising the manpage.
 
 .SH NAME
@@ -6,7 +6,7 @@ render_list \- renders a list of map tiles by sending requests to a rendering da
 
 .SH SYNOPSIS
 .B render_list
-.RI [ options ] <  "render.list"
+.RI [ options ]\ <\  "render.list"
 .BR
 
 .SH DESCRIPTION
@@ -26,43 +26,64 @@ A summary of options is included below.
 \fB\-a\fR|\-\-all
 Render all tiles in given zoom level range instead of reading from STDIN.
 .TP
+\fB\-c\fR|\-\-config=CONFIG
+Specify a `renderd.conf` file from which to load various option values rather than specifying via command line.
+.sp 0
+The following options will be set (if present); however, they can be overridden if also specified:
+.sp 0
+\fB\-s\fR|\-\-socket
+.sp 0
+\fB\-n\fR|\-\-num-threads
+.sp 0
+\fB\-t\fR|\-\-tile-dir
+.sp 0
+\fB\-z\fR|\-\-min-zoom
+.sp 0
+\fB\-Z\fR|\-\-max-zoom
+.TP
 \fB\-f\fR|\-\-force
 Render tiles even if they seem current.
 .TP
 \fB\-m\fR|\-\-map=MAP
-Render tiles in this map (defaults to 'default').
+Render tiles in this map (default is 'default').
 .TP
 \fB\-l\fR|\-\-max-load=LOAD
-Sleep if load is this high (defaults to 16).
+Sleep if load is this high (default is '16').
 .TP
 \fB\-s\fR|\-\-socket=SOCKET|HOSTNAME:PORT
-Unix domain socket name or hostname and port for contacting renderd.
+Unix domain socket name or hostname and port for contacting renderd (default is '/var/run/renderd/renderd.sock').
 .TP
 \fB\-n\fR|\-\-num-threads=N
-The number of parallel request threads (default 1).
+The number of parallel request threads (default is '1').
 .TP
-\fB\-t\fR|\-\-tile-dir
-Tile cache directory (defaults to '/var/cache/renderd/tiles').
+\fB\-t\fR|\-\-tile-dir=TILE_DIR
+Tile cache directory (default is '/var/cache/renderd/tiles').
 .TP
 \fB\-z\fR|\-\-min-zoom=ZOOM
-Filter input to only render tiles greater or equal to this zoom level (default is 0).
+Filter input to only render tiles greater than or equal to this zoom level (default is '0').
 .TP
 \fB\-Z\fR|\-\-max-zoom=ZOOM
-Filter input to only render tiles less than or equal to this zoom level (default is 20).
+Filter input to only render tiles less than or equal to this zoom level (default is '20').
+.TP
+\fB\-h\fR|\-\-help
+Print out a help text for render_list
+.TP
+\fB\-V\fR|\-\-version
+Print out the version number for render_list
 .PP
-If you are using --all, you can restrict the tile range by adding these options:
-.BR
-  (please note that tile coordinates must be positive integers and are not latitude and longitude values)
-.BR
-  -x, --min-x=X        minimum X tile coordinate
-.BR
-  -X, --max-x=X        maximum X tile coordinate
-.BR
-  -y, --min-y=Y        minimum Y tile coordinate
-.BR
-  -Y, --max-y=Y        maximum Y tile coordinate
+If you are using \fB\-a\fR|\-\-all, you can restrict the tile range by adding these options:
+.sp 0
+(please note that tile coordinates must be positive integers and are not latitude and longitude values)
 .PP
-Without --all, send a list of tiles to be rendered from STDIN in the format:
+  \fB\-x\fR|\-\-min-x=X        minimum X tile coordinate
+.BR
+  \fB\-X\fR|\-\-max-x=X        maximum X tile coordinate
+.BR
+  \fB\-y\fR|\-\-min-y=Y        minimum Y tile coordinate
+.BR
+  \fB\-Y\fR|\-\-max-y=Y        maximum Y tile coordinate
+.PP
+Without \fB\-a\fR|\-\-all, send a list of tiles to be rendered from STDIN in the format:
 .BR
   X Y Z
 .BR
@@ -75,14 +96,8 @@ e.g.
   1 0 1
 .BR
   1 1 1
-.BR
+.PP
 The above would cause all 4 tiles at zoom 1 to be rendered
-.TP
-\fB\-h\fR|\-\-help
-Print out a help text for render_list
-.TP
-\fB\-V\fR|\-\-version
-Print out the version number for render_list
 .PP
 
 .SH SEE ALSO

--- a/src/render_list.c
+++ b/src/render_list.c
@@ -52,7 +52,7 @@ void display_rate(struct timeval start, struct timeval end, int num)
 
 	sec = d_s + d_us / 1000000.0;
 
-	g_logger(G_LOG_LEVEL_MESSAGE, "\tRendered %d tiles in %.2f seconds (%.2f tiles/s)", num, sec, num / sec);
+	g_logger(G_LOG_LEVEL_MESSAGE, "\t%d in %.2f seconds (%.2f/s)", num, sec, num / sec);
 }
 
 int main(int argc, char **argv)
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 	int max_load_default = MAX_LOAD_OLD;
 	int max_x_default = -1;
 	int max_y_default = -1;
-	int max_zoom_default = 18;
+	int max_zoom_default = MAX_ZOOM;
 	int min_x_default = -1;
 	int min_y_default = -1;
 	int min_zoom_default = 0;
@@ -225,21 +225,21 @@ int main(int argc, char **argv)
 				fprintf(stderr, "  -f, --force                       render tiles even if they seem current\n");
 				fprintf(stderr, "  -l, --max-load=LOAD               sleep if load is this high (default is '%d')\n", max_load_default);
 				fprintf(stderr, "  -m, --map=MAP                     render tiles in this map (default is '%s')\n", mapname_default);
-				fprintf(stderr, "  -l, --max-load=LOAD               sleep if load is this high (default is '%d')\n", max_load_default);
+				fprintf(stderr, "  -n, --num-threads=N               the number of parallel request threads (default is '%i')\n", num_threads_default);
 				fprintf(stderr, "  -s, --socket=SOCKET|HOSTNAME:PORT unix domain socket name or hostname and port for contacting renderd (default is '%s')\n", socketname_default);
 				fprintf(stderr, "  -t, --tile-dir=TILE_DIR           tile cache directory (default is '%s')\n", tile_dir_default);
 				fprintf(stderr, "  -Z, --max-zoom=ZOOM               filter input to only render tiles less than or equal to this zoom level (default is '%d')\n", max_zoom_default);
 				fprintf(stderr, "  -z, --min-zoom=ZOOM               filter input to only render tiles greater than or equal to this zoom level (default is '%d')\n", min_zoom_default);
 				fprintf(stderr, "\n");
+				fprintf(stderr, "  -h, --help                        display this help and exit\n");
+				fprintf(stderr, "  -V, --version                     display the version number and exit\n");
+				fprintf(stderr, "\n");
 				fprintf(stderr, "If you are using --all, you can restrict the tile range by adding these options:\n");
-				fprintf(stderr, "  (please note that tile coordinates must be positive integers and are not latitude and longitude values)\n");
+				fprintf(stderr, "(please note that tile coordinates must be positive integers and are not latitude and longitude values)\n");
 				fprintf(stderr, "  -X, --max-x=X                     maximum X tile coordinate\n");
 				fprintf(stderr, "  -x, --min-x=X                     minimum X tile coordinate\n");
 				fprintf(stderr, "  -Y, --max-y=Y                     maximum Y tile coordinate\n");
 				fprintf(stderr, "  -y, --min-y=Y                     minimum Y tile coordinate\n");
-				fprintf(stderr, "\n");
-				fprintf(stderr, "  -h, --help                        display this help and exit\n");
-				fprintf(stderr, "  -V, --version                     display the version number and exit\n");
 				fprintf(stderr, "\n");
 				fprintf(stderr, "Without --all, send a list of tiles to be rendered from STDIN in the format:\n");
 				fprintf(stderr, "  X Y Z\n");
@@ -436,7 +436,7 @@ int main(int argc, char **argv)
 				// Attempts to adjust the stats for the QMAX tiles which are likely in the queue
 				if (!(num_render % 10)) {
 					gettimeofday(&end, NULL);
-					g_logger(G_LOG_LEVEL_MESSAGE, "Meta tiles rendered:");
+					g_logger(G_LOG_LEVEL_MESSAGE, "Metatiles rendered:");
 					display_rate(start, end, num_render);
 					g_logger(G_LOG_LEVEL_MESSAGE, "Total tiles rendered:");
 					display_rate(start, end, num_render * METATILE * METATILE);
@@ -475,7 +475,7 @@ int main(int argc, char **argv)
 
 	gettimeofday(&end, NULL);
 	g_logger(G_LOG_LEVEL_MESSAGE, "Total for all tiles rendered");
-	g_logger(G_LOG_LEVEL_MESSAGE, "Meta tiles rendered:");
+	g_logger(G_LOG_LEVEL_MESSAGE, "Metatiles rendered:");
 	display_rate(start, end, num_render);
 	g_logger(G_LOG_LEVEL_MESSAGE, "Total tiles rendered:");
 	display_rate(start, end, num_render * METATILE * METATILE);

--- a/src/render_speedtest.cpp
+++ b/src/render_speedtest.cpp
@@ -120,7 +120,7 @@ void display_rate(struct timeval start, struct timeval end, int num)
 
 	sec = d_s + d_us / 1000000.0;
 
-	g_logger(G_LOG_LEVEL_MESSAGE, "\tRendered %d tiles in %.2f seconds (%.2f tiles/s)", num, sec, num / sec);
+	g_logger(G_LOG_LEVEL_MESSAGE, "\t%d in %.2f seconds (%.2f/s)", num, sec, num / sec);
 }
 
 int main(int argc, char **argv)
@@ -128,7 +128,7 @@ int main(int argc, char **argv)
 	const char *config_file_name_default = RENDERD_CONFIG;
 	const char *mapname_default = XMLCONFIG_DEFAULT;
 	const char *socketname_default = RENDERD_SOCKET;
-	int max_zoom_default = 18;
+	int max_zoom_default = MAX_ZOOM;
 	int min_zoom_default = 0;
 	int num_threads_default = 1;
 

--- a/src/render_submit_queue.c
+++ b/src/render_submit_queue.c
@@ -57,7 +57,7 @@ struct speed_stat {
 	time_t time_min;
 	time_t time_max;
 	time_t time_total;
-	int    noRendered;
+	int noRendered;
 };
 
 struct speed_stats {
@@ -84,7 +84,7 @@ static void check_load(void)
 	}
 }
 
-static int process(struct protocol * cmd, int fd)
+static int process(struct protocol *cmd, int fd)
 {
 	struct timeval tim;
 	time_t t1;
@@ -143,7 +143,7 @@ static int process(struct protocol * cmd, int fd)
 	return ret;
 }
 
-static struct protocol * fetch(void)
+static struct protocol *fetch(void)
 {
 	pthread_mutex_lock(&qLock);
 
@@ -174,7 +174,7 @@ static struct protocol * fetch(void)
 	pthread_cond_signal(&qCondNotFull);
 	pthread_mutex_unlock(&qLock);
 
-	struct protocol * cmd = malloc(sizeof(struct protocol));
+	struct protocol *cmd = malloc(sizeof(struct protocol));
 
 	cmd->ver = 2;
 	cmd->cmd = cmdRenderBulk;
@@ -248,7 +248,7 @@ int make_connection(const char *spath)
 		addr.sun_family = AF_UNIX;
 		strncpy(addr.sun_path, spath, sizeof(addr.sun_path) - 1);
 
-		if (connect(fd, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
+		if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
 			close(fd);
 			return -1;
 		}
@@ -340,7 +340,6 @@ int make_connection(const char *spath)
 				g_logger(G_LOG_LEVEL_DEBUG, "Connected to %s:%s", resolved_addr, resolved_port);
 				break;
 			}
-
 		}
 
 		freeaddrinfo(result);
@@ -349,7 +348,6 @@ int make_connection(const char *spath)
 			g_logger(G_LOG_LEVEL_CRITICAL, "cannot connect to any address for %s", hostname);
 			exit(2);
 		}
-
 	}
 
 	return fd;
@@ -366,7 +364,7 @@ void *thread_main(void *arg)
 	}
 
 	while (1) {
-		struct protocol * cmd;
+		struct protocol *cmd;
 		check_load();
 
 		if (!(cmd = fetch())) {
@@ -436,7 +434,7 @@ void print_statistics(void)
 		}
 
 		printf("Zoom %02i: min: %4.1f    avg: %4.1f     max: %4.1f     over a total of %8.1fs in %i requests\n",
-		       i, performance_stats.stat[i].time_min / 1000.0, (performance_stats.stat[i].time_total / (float) performance_stats.stat[i].noRendered) / 1000.0,
+		       i, performance_stats.stat[i].time_min / 1000.0, (performance_stats.stat[i].time_total / (float)performance_stats.stat[i].noRendered) / 1000.0,
 		       performance_stats.stat[i].time_max / 1000.0, performance_stats.stat[i].time_total / 1000.0, performance_stats.stat[i].noRendered);
 	}
 


### PR DESCRIPTION
_Also updated all render\_* apps to_:
* Use `MAX_ZOOM` rather than hard-coded values for `--max-zoom`
* Print `metatile` rather than `meta tile`
* Add missing `--help` output to `render_expired` & `render_list`
* Remove redundant `--help` output from `render_list`