### PR TITLE
Add macOS 14 to build and test CI workflow

### DIFF
--- a/.github/actions/autotools/install/action.yml
+++ b/.github/actions/autotools/install/action.yml
@@ -3,9 +3,9 @@ runs:
   using: composite
   steps:
     - name: Run `make install`
-      run: make install
+      run: ${{ !matrix.image && 'sudo -E' || '' }} make install
       shell: bash --noprofile --norc -euxo pipefail {0}
 
     - name: Run `make install-mod_tile`
-      run: make install-mod_tile
+      run: ${{ !matrix.image && 'sudo -E' || '' }} make install-mod_tile
       shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,8 +83,7 @@ jobs:
 
       - name: Package `mod_tile`
         uses: ./.github/actions/cmake/package
-        if: |
-          matrix.build_system == 'CMake'
+        if: matrix.build_system == 'CMake'
 
       - name: Install `mod_tile`
         uses: ./.github/actions/install
@@ -135,8 +134,7 @@ jobs:
 
       - name: Package `mod_tile`
         uses: ./.github/actions/cmake/package
-        if: |
-          matrix.build_system == 'CMake'
+        if: matrix.build_system == 'CMake'
 
       - name: Install `mod_tile`
         uses: ./.github/actions/install
@@ -146,7 +144,6 @@ jobs:
       CFLAGS: --coverage
       CXXFLAGS: --coverage
       LDFLAGS: -undefined dynamic_lookup
-      LIBRARY_PATH: /usr/local/lib
       TEST_PARALLEL_LEVEL: 1
     name: >-
       ${{ matrix.os }}
@@ -158,6 +155,7 @@ jobs:
       matrix:
         os:
           - macos-12
+          - macos-13
         build_system:
           - CMake
         compiler:
@@ -165,10 +163,10 @@ jobs:
         on_default_branch:
           - ${{ contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'CI') }}
         include:
-          - os: macos-13
+          - os: macos-14
             build_system: Autotools
             compiler: LLVM
-          - os: macos-13
+          - os: macos-14
             build_system: CMake
             compiler: LLVM
         exclude:
@@ -180,9 +178,11 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/dependencies/install
 
-      - name: Set ICU_ROOT
+      - name: Set CPATH, ICU_ROOT & LIBRARY_PATH
         run: |
+          echo "CPATH=$(brew --prefix)/include" >> ${GITHUB_ENV}
           echo "ICU_ROOT=$(brew --prefix icu4c)" >> ${GITHUB_ENV}
+          echo "LIBRARY_PATH=$(brew --prefix)/lib" >> ${GITHUB_ENV}
 
       - name: Build `mod_tile`
         uses: ./.github/actions/build
@@ -199,8 +199,7 @@ jobs:
 
       - name: Package `mod_tile`
         uses: ./.github/actions/cmake/package
-        if: |
-          matrix.build_system == 'CMake'
+        if: matrix.build_system == 'CMake'
 
       - name: Install `mod_tile`
         uses: ./.github/actions/install

--- a/docs/build/building_on_macos.md
+++ b/docs/build/building_on_macos.md
@@ -4,7 +4,7 @@ This document provides users with step-by-step instructions on how to compile an
 
 Please see our [Continuous Integration script](/.github/workflows/build-and-test.yml) for more details.
 
-## macOS 11/12/13
+## macOS 11/12/13/14
 
 ```shell
 #!/usr/bin/env bash
@@ -28,11 +28,11 @@ brew install \
   pkg-config
 
 # Download, Build, Test & Install `mod_tile`
-export CFLAGS="-Wno-implicit-function-declaration"
 export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+export CPATH=$(brew --prefix)/include
 export ICU_ROOT=$(brew --prefix icu4c)
 export LDFLAGS="-undefined dynamic_lookup"
-export LIBRARY_PATH="/usr/local/lib"
+export LIBRARY_PATH=$(brew --prefix)/lib
 rm -rf /tmp/mod_tile_src /tmp/mod_tile_build
 mkdir /tmp/mod_tile_src /tmp/mod_tile_build
 cd /tmp/mod_tile_src


### PR DESCRIPTION
Available since January 30th, 2024:
https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/