### PR TITLE
Added `continue-on-error` for experimental distros

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   Linux:
+    continue-on-error: ${{ matrix.experimental || false }}
     name: >-
       ${{ matrix.image }}
       (${{ matrix.build_system }})
@@ -14,25 +15,34 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image:
-          - "debian:11"
-          - "debian:12"
-          - "debian:testing"
-          - "fedora:38"
-          - "fedora:39"
-          - "fedora:rawhide"
-          - "opensuse/leap:15"
-          - "quay.io/centos/centos:stream8"
-          - "quay.io/centos/centos:stream9"
-          - "ubuntu:20.04"
-          - "ubuntu:rolling"
         build_system:
           - CMake
         compiler:
           - GNU
+        image:
+          - "debian:11"
+          - "debian:12"
+          - "fedora:38"
+          - "fedora:39"
+          - "opensuse/leap:15"
+          - "quay.io/centos/centos:stream8"
+          - "quay.io/centos/centos:stream9"
+          - "ubuntu:20.04"
         on_default_branch:
           - ${{ contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'CI') }}
         include:
+          - image: "debian:unstable"
+            build_system: CMake
+            compiler: GNU
+            experimental: true
+          - image: "fedora:rawhide"
+            build_system: CMake
+            compiler: GNU
+            experimental: true
+          - image: "ubuntu:devel"
+            build_system: CMake
+            compiler: GNU
+            experimental: true
           - image: "ubuntu:22.04"
             build_system: Autotools
             compiler: GNU
@@ -77,9 +87,7 @@ jobs:
         if: |
           matrix.build_system == 'CMake' &&
           matrix.compiler != 'LLVM' &&
-          matrix.image != 'debian:testing' &&
-          matrix.image != 'opensuse/leap:15' &&
-          matrix.image != 'ubuntu:rolling'
+          !matrix.experimental
 
       - name: Package `mod_tile`
         uses: ./.github/actions/cmake/package
@@ -207,7 +215,6 @@ jobs:
         uses: ./.github/actions/install
 
   FreeBSD:
-    continue-on-error: true
     env:
       CFLAGS: --coverage
       CTEST_CLIENT_HOST: ::1

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   docker-image-build:
+    continue-on-error: ${{ matrix.experimental || false }}
     name: Build & Test (${{ matrix.service-name }})
     runs-on: ubuntu-latest
     strategy:
@@ -21,17 +22,24 @@ jobs:
           - centos-stream-9
           - debian-11
           - debian-12
-          - debian-testing
-          - debian-testing-autotools
           - fedora-38
           - fedora-39
-          - fedora-rawhide
           - opensuse-leap-15
-          - opensuse-tumbleweed
           - ubuntu-20.04
           - ubuntu-22.04
-          - ubuntu-devel
-          - ubuntu-devel-autotools
+        include:
+          - service-name: debian-unstable
+            experimental: true
+          - service-name: debian-unstable-autotools
+            experimental: true
+          - service-name: fedora-rawhide
+            experimental: true
+          - service-name: opensuse-tumbleweed
+            experimental: true
+          - service-name: ubuntu-devel
+            experimental: true
+          - service-name: ubuntu-devel-autotools
+            experimental: true
       fail-fast: false
     steps:
       - name: Checkout repository

--- a/.github/workflows/install-package-and-test.yml
+++ b/.github/workflows/install-package-and-test.yml
@@ -18,7 +18,9 @@ jobs:
         image:
           - "debian:11"
           - "debian:12"
+          - "debian:unstable"
           - "ubuntu:22.04"
+          - "ubuntu:devel"
       fail-fast: false
     container:
       image: ${{ matrix.image }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,7 +11,7 @@ For your convenience, we have provided a Docker-based building and testing metho
 - debian-10 _(Debian 10)_ [[Dockerfile](/docker/debian/Dockerfile)]
 - debian-11 _(Debian 11)_ [[Dockerfile](/docker/debian/Dockerfile)]
 - debian-12 _(Debian 12)_ [[Dockerfile](/docker/debian/Dockerfile)]
-- debian-testing _(Debian Testing)_ [[Dockerfile](/docker/debian/Dockerfile)]
+- debian-unstable _(Debian Unstable)_ [[Dockerfile](/docker/debian/Dockerfile)]
 - fedora-34 _(Fedora 34)_ [[Dockerfile](/docker/fedora/Dockerfile)]
 - fedora-35 _(Fedora 35)_ [[Dockerfile](/docker/fedora/Dockerfile)]
 - fedora-36 _(Fedora 36)_ [[Dockerfile](/docker/fedora/Dockerfile)]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -146,20 +146,20 @@ services:
         libmapnik_version: "3.1"
         debian_version: "12"
       dockerfile: docker/debian/Dockerfile.autotools
-  debian-testing:
+  debian-unstable:
     <<: *service_defaults
     build:
       <<: *build_defaults_debian
       args:
         libmapnik_version: "3.1"
-        debian_version: testing
-  debian-testing-autotools:
+        debian_version: unstable
+  debian-unstable-autotools:
     <<: *service_defaults
     build:
       <<: *build_defaults_debian
       args:
         libmapnik_version: "3.1"
-        debian_version: testing
+        debian_version: unstable
       dockerfile: docker/debian/Dockerfile.autotools
   fedora-34:
     <<: *service_defaults


### PR DESCRIPTION
So that workflows will still show  as passing.

* Build & Test
  * debian:unstable
  * fedora:rawhide
  * ubuntu:devel
* Docker Image Build
  * debian-unstable/debian-unstable-autotools
  * fedora-rawhide
  * opensuse-tumbleweed
  * ubuntu-devel/ubuntu-devel-autotools