### PR TITLE
Prevent duplicate `renderd` sections in `renderd.conf`

### DIFF
--- a/src/renderd_config.c
+++ b/src/renderd_config.c
@@ -400,6 +400,11 @@ void process_renderd_sections(const char *config_file_name, renderd_config *conf
 				exit(7);
 			}
 
+			if (configs_dest[renderd_section_num].name != NULL) {
+				g_logger(G_LOG_LEVEL_CRITICAL, "Duplicate renderd config section names for section %i: %s & %s", renderd_section_num, configs_dest[renderd_section_num].name, section);
+				exit(7);
+			}
+
 			copy_string(section, &configs_dest[renderd_section_num].name, renderd_strlen + 2);
 
 			process_config_int(ini, section, "ipport", &configs_dest[renderd_section_num].ipport, 0);


### PR DESCRIPTION
In order to remove any confusion if the user has duplicate `renderd` sections in their `renderd.conf` file.

Currently with a configuration like this one:
```ini
[renderd]
pid_file=/run/renderd/renderd.pid
socketname=/run/renderd/renderd.sock
stats_file=/run/renderd/renderd.stats
tile_dir=/var/cache/renderd/tiles

[renderd0]
pid_file=/run/renderd/renderd0.pid
socketname=/run/renderd/renderd0.sock
stats_file=/run/renderd/renderd0.stats
tile_dir=/var/cache/renderd/tiles
```
only the second `renderd` section (`renderd0`) will actually be used.

After this patch is merged, an error message will be shown and the application will exit.