### PR TITLE
Add Fedora 40 to build pipeline

### DIFF
--- a/.github/actions/autotools/build/action.yml
+++ b/.github/actions/autotools/build/action.yml
@@ -6,10 +6,6 @@ runs:
       run: ./autogen.sh
       shell: bash --noprofile --norc -euxo pipefail {0}
 
-    - name: Create `build` directory link
-      run: ln -s . build
-      shell: bash --noprofile --norc -euxo pipefail {0}
-
     - name: Run `./configure`
       run: ./configure
       shell: bash --noprofile --norc -euxo pipefail {0}

--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -8,13 +8,21 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Process `mod_tile` coverage results
+    - name: Process `mod_tile` coverage results with CTest
       run: |
         ctest -T coverage || true
+      shell: bash --noprofile --norc -euxo pipefail {0}
+      working-directory: build
+      if: matrix.build_system == 'CMake'
+
+    - name: Process `mod_tile` coverage results
+      run: |
         lcov ${{ inputs.lcov-extra-options }} \
+          --base-directory . \
           --capture \
-          --directory . \
-          --output-file coverage.info
+          --directory ${{ matrix.build_system == 'CMake' && 'build' || '.' }} \
+          --output-file coverage.info \
+          --rc geninfo_unexecuted_blocks=1
         lcov ${{ inputs.lcov-extra-options }} \
           --output-file coverage.info \
           --remove coverage.info \
@@ -22,12 +30,11 @@ runs:
           "${GITHUB_WORKSPACE}/tests/*" \
           "/usr/*"
       shell: bash --noprofile --norc -euxo pipefail {0}
-      working-directory: build
 
     - name: Report `mod_tile` coverage results to `codecov.io`
       uses: codecov/codecov-action@v3.1.5
       with:
-        files: build/coverage.info
+        files: coverage.info
 
     - name: Write `mod_tile` coverage summary to `$GITHUB_STEP_SUMMARY`
       run: |
@@ -35,7 +42,6 @@ runs:
           --summary \
           coverage.info | sed 's/^  /* /g' >> ${GITHUB_STEP_SUMMARY}
       shell: bash --noprofile --norc -euxo pipefail {0}
-      working-directory: build
 
     - name: Generate `mod_tile` coverage artifacts
       run: |
@@ -43,7 +49,6 @@ runs:
           --output-directory coverage \
           coverage.info
       shell: bash --noprofile --norc -euxo pipefail {0}
-      working-directory: build
 
     - name: Set `COVERAGE_ARTIFACT_NAME`
       run: |
@@ -55,5 +60,5 @@ runs:
       with:
         name: Coverage Artifacts - ${{ env.COVERAGE_ARTIFACT_NAME }}${{ matrix.mapnik_latest && ' (Latest Mapnik)' || '' }}
         path: |
-          build/coverage
-          build/coverage.info
+          coverage
+          coverage.info

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -202,8 +202,8 @@ jobs:
       - name: Process & Report `mod_tile` coverage results
         uses: ./.github/actions/coverage
         with:
-          genhtml-extra-options: --ignore-errors inconsistent --ignore-errors unmapped
-          lcov-extra-options: --ignore-errors gcov --ignore-errors inconsistent
+          genhtml-extra-options: --keep-going --ignore-errors count,inconsistent,range
+          lcov-extra-options: --keep-going --ignore-errors count,inconsistent,range
 
       - name: Package `mod_tile`
         uses: ./.github/actions/cmake/package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -22,8 +22,8 @@ jobs:
         image:
           - "debian:11"
           - "debian:12"
-          - "fedora:38"
           - "fedora:39"
+          - "fedora:40"
           - "opensuse/leap:15"
           - "quay.io/centos/centos:stream8"
           - "quay.io/centos/centos:stream9"

--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -22,8 +22,8 @@ jobs:
           - centos-stream-9
           - debian-11
           - debian-12
-          - fedora-38
           - fedora-39
+          - fedora-40
           - opensuse-leap-15
           - ubuntu-20.04
           - ubuntu-22.04

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,6 +18,7 @@ For your convenience, we have provided a Docker-based building and testing metho
 - fedora-37 _(Fedora 37)_ [[Dockerfile](/docker/fedora/Dockerfile)]
 - fedora-38 _(Fedora 38)_ [[Dockerfile](/docker/fedora/Dockerfile)]
 - fedora-39 _(Fedora 39)_ [[Dockerfile](/docker/fedora/Dockerfile)]
+- fedora-40 _(Fedora 40)_ [[Dockerfile](/docker/fedora/Dockerfile)]
 - fedora-rawhide _(Fedora Rawhide)_ [[Dockerfile](/docker/fedora/Dockerfile)]
 - opensuse-leap-15 _(openSUSE Leap 15)_ [[Dockerfile](/docker/opensuse/Dockerfile)]
 - opensuse-tumbleweed _(openSUSE Tumbleweed)_ [[Dockerfile](/docker/opensuse/Dockerfile)]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -197,6 +197,12 @@ services:
       <<: *build_defaults_fedora
       args:
         fedora_version: "39"
+  fedora-40:
+    <<: *service_defaults
+    build:
+      <<: *build_defaults_fedora
+      args:
+        fedora_version: "40"
   fedora-rawhide:
     <<: *service_defaults
     build:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,4 @@
 ---
-version: "3.8"
-
 x-mod_tile:
   build_defaults: &build_defaults
     context: ..
@@ -215,6 +213,7 @@ services:
       <<: *build_defaults_opensuse
       args:
         boost_version: "1_75_0"
+        gcc_version: "13"
         opensuse_version: "leap:15"
   opensuse-tumbleweed:
     <<: *service_defaults

--- a/docker/opensuse/Dockerfile
+++ b/docker/opensuse/Dockerfile
@@ -1,5 +1,6 @@
 # Arguments
 ARG boost_version
+ARG gcc_version
 ARG opensuse_version=leap:15
 
 # Mapnik Builder
@@ -7,6 +8,7 @@ FROM opensuse/${opensuse_version} as mapnik-builder
 
 ## Arguments
 ARG boost_version
+ARG gcc_version
 ARG opensuse_version
 
 ## Install mapnik-builder dependencies
@@ -17,8 +19,8 @@ RUN --mount=id=opensuse:${opensuse_version}-/var/cache/zypp,target=/var/cache/zy
         cairo-devel \
         cmake \
         freetype-devel \
-        gcc \
-        gcc-c++ \
+        gcc${gcc_version} \
+        gcc${gcc_version}-c++ \
         gdal-devel \
         git \
         harfbuzz-devel \
@@ -39,7 +41,13 @@ RUN --mount=id=opensuse:${opensuse_version}-/var/cache/zypp,target=/var/cache/zy
         python3 \
         sqlite3-devel \
         tar \
-        zlib-devel
+        zlib-devel && \
+    if [ -n "${gcc_version}" ]; then \
+        update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 10; \
+        update-alternatives --install /usr/bin/cc gcc /usr/bin/gcc-${gcc_version} 10; \
+        update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${gcc_version} 10; \
+        update-alternatives --install /usr/bin/c++ g++ /usr/bin/g++-${gcc_version} 10; \
+    fi
 
 ## Download, Build & Install `Mapnik`
 WORKDIR /tmp/mapnik_src
@@ -53,9 +61,12 @@ RUN --mount=id=opensuse:${opensuse_version}-mapnik-src:latest,target=/tmp/mapnik
     export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc) && \
     export DESTDIR=/tmp/mapnik && \
     cmake -B . -S /tmp/mapnik_src \
+        -DBUILD_BENCHMARK:BOOL=OFF \
+        -DBUILD_DEMO_CPP:BOOL=OFF \
         -DBUILD_DEMO_VIEWER:BOOL=OFF \
         -DBUILD_TESTING:BOOL=OFF \
         -DCMAKE_BUILD_TYPE:STRING=Release \
+        -DCMAKE_CXX_STANDARD:STRING=17 \
         -DCMAKE_INSTALL_PREFIX:PATH=/usr \
         -DMAPNIK_PKGCONF_DIR:PATH=/usr/share/pkgconfig && \
     cmake --build . && \

--- a/docs/build/building_on_fedora.md
+++ b/docs/build/building_on_fedora.md
@@ -6,7 +6,7 @@ Please see our [Continuous Integration script](/.github/workflows/build-and-test
 
 A Docker-based building & testing setup pipeline is also available [here](/docker) for your convenience.
 
-## Fedora 34/35/36/37/38/39
+## Fedora 34/35/36/37/38/39/40
 
 ```shell
 #!/usr/bin/env bash


### PR DESCRIPTION
_And_:
* Remove Fedora 38
* Fix `openSUSE Leap 15` Docker build's default GCC no longer compiles `Mapnik` latest
  * C++17 is now required, so a newer GCC will be installed
* Fix for coverage capturing with LCOV 2.1
  * Seems to currently only exist on macOS