### PR TITLE
Increase `XMLCONFIGS_MAX` default from `10` to `100`

### DIFF
--- a/includes/render_config.h
+++ b/includes/render_config.h
@@ -58,7 +58,7 @@
 #endif
 // Maximum number of configurations that mod tile will allow
 #ifndef XMLCONFIGS_MAX
-#define XMLCONFIGS_MAX 10
+#define XMLCONFIGS_MAX 100
 #endif
 // Default PID file path
 #ifndef RENDERD_PIDFILE


### PR DESCRIPTION
Resolves https://github.com/openstreetmap/mod_tile/issues/396