### PR TITLE
Minor fixes

### DIFF
--- a/.github/actions/coverage/action.yml
+++ b/.github/actions/coverage/action.yml
@@ -24,6 +24,7 @@ runs:
           --output-file coverage.info \
           --rc geninfo_unexecuted_blocks=1
         lcov ${{ inputs.lcov-extra-options }} \
+          --ignore-errors unused \
           --output-file coverage.info \
           --remove coverage.info \
           "${GITHUB_WORKSPACE}/includes/*" \

--- a/docs/build/building_on_ubuntu.md
+++ b/docs/build/building_on_ubuntu.md
@@ -6,7 +6,7 @@ Please see our [Continuous Integration script](/.github/workflows/build-and-test
 
 A Docker-based building & testing setup pipeline is also available [here](/docker) for your convenience.
 
-# Ubuntu 20.04/22.04.24.04
+# Ubuntu 20.04/22.04/24.04
 
 ```shell
 #!/usr/bin/env bash

--- a/src/parameterize_style.cpp
+++ b/src/parameterize_style.cpp
@@ -68,11 +68,7 @@ static void parameterize_map_language(mapnik::Map &m, char *parameter)
 		mapnik::parameters params = l.datasource()->params();
 
 		if (params.find("table") != params.end()) {
-#if MAPNIK_MAJOR_VERSION >= 4
-			std::optional<std::string> table = params.get<std::string>("table");
-#else
-			boost::optional<std::string> table = params.get<std::string>("table");
-#endif
+			auto table = params.get<std::string>("table");
 
 			if (table && table->find(",name") != std::string::npos) {
 				std::string str = *table;


### PR DESCRIPTION
* `.github/actions/coverage/action.yml`
  * Ignore `unused` errors when excluding coverage directories
* `docs/build/building_on_ubuntu.md`
  * Fix typo
* `src/parameterize_style.cpp`
  * Use `auto` rather than `std::optional<std::string>`/`boost::optional<std::string>`