### PR TITLE
Clarify optional libraries and allow optionally disabling them

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -172,9 +172,6 @@ jobs:
           - ${{ contains(github.ref, 'master') || contains(github.ref, 'develop') || contains(github.ref, 'CI') }}
         include:
           - os: macos-14
-            build_system: Autotools
-            compiler: LLVM
-          - os: macos-14
             build_system: CMake
             compiler: LLVM
         exclude:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,13 @@ set(CMAKE_CXX_STANDARD 11 CACHE STRING "Sets the C++ standard.")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
+set(CMAKE_INSTALL_MODULESDIR CACHE PATH "Apache HTTP Server module installation directory")
 set(ENABLE_MAN ON CACHE BOOL "Build man pages")
 set(ENABLE_TESTS OFF CACHE BOOL "Build test suite")
-set(CMAKE_INSTALL_MODULESDIR CACHE PATH "Apache HTTP Server module installation directory")
+set(USE_CAIRO ON CACHE BOOL "Add cairo support if available (for `store_ro_composite.c` backend)")
+set(USE_CURL ON CACHE BOOL "Add curl support if available (for `store_ro_http_proxy.c` backend)")
+set(USE_MEMCACHED ON CACHE BOOL "Add memcached support if available (for `store_memcached.c` backend)")
+set(USE_RADOS ON CACHE BOOL "Add rados support if available (for `store_rados.c` backend)")
 
 #-----------------------------------------------------------------------------
 #
@@ -38,21 +42,30 @@ set(CMAKE_INSTALL_MODULESDIR CACHE PATH "Apache HTTP Server module installation 
 include(GNUInstallDirs)
 
 # Packages
-find_package(CURL)
 find_package(ICU REQUIRED uc)
 find_package(Threads REQUIRED)
 
 find_package(APR REQUIRED)
-find_package(CAIRO REQUIRED)
 find_package(GLIB 2.50 REQUIRED)
 find_package(HTTPD 2.4 REQUIRED)
 find_package(INIPARSER REQUIRED)
 find_package(LIBMAPNIK 3 REQUIRED)
-find_package(LIBMEMCACHED)
-find_package(LIBRADOS)
 
 if(LIBMAPNIK_VERSION VERSION_GREATER_EQUAL 4)
   set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(USE_CURL)
+  find_package(CURL)
+endif()
+if(USE_CAIRO)
+  find_package(CAIRO)
+endif()
+if(USE_MEMCACHED)
+  find_package(LIBMEMCACHED)
+endif()
+if(USE_RADOS)
+  find_package(LIBRADOS)
 endif()
 
 # Programs

--- a/README.rst
+++ b/README.rst
@@ -22,19 +22,19 @@ Dependencies
 ------------
 
 * `Supported Operating Systems`
-    * `GNU/Linux` (works best on Debian or Ubuntu)
     * `FreeBSD`
+    * `GNU/Linux`
     * `macOS`
 * `Supported Build Systems`
-    * `GNU Autotools <https://www.gnu.org/software/software.html>`__
     * `CMake <https://cmake.org/>`__
+    * `GNU Autotools <https://www.gnu.org/software/software.html>`__
 * `Runtime/Build Dependencies`
     * `Apache 2 HTTP webserver <https://httpd.apache.org/>`__
-    * `Mapnik <https://mapnik.org/>`__
-    * `Cairo 2D graphics library  <https://cairographics.org/>`__
-    * `Curl library (SSL variant) <https://curl.haxx.se/>`__
-    * `Iniparser library <https://github.com/ndevilla/iniparser>`__
+    * `Cairo 2D graphics library (optional) <https://cairographics.org/>`__
+    * `Curl library (optional) <https://curl.haxx.se/>`__
     * `GLib library <https://gitlab.gnome.org/GNOME/glib>`__
+    * `Iniparser library <https://github.com/ndevilla/iniparser>`__
+    * `Mapnik library <https://mapnik.org/>`__
     * `Memcached library (optional) <https://libmemcached.org/>`__
     * `RADOS library (optional) <https://docs.ceph.com/en/latest/rados/api/librados/>`__
 

--- a/tests/gen_tile_test.cpp
+++ b/tests/gen_tile_test.cpp
@@ -1206,8 +1206,31 @@ TEST_CASE("rados storage-backend", "RADOS Tile storage backend")
 	}
 }
 
+TEST_CASE("ro_composite storage-backend", "RO Composite Tile storage backend")
+{
+	int found;
+	std::string err_log_lines, out_log_lines;
+	struct storage_backend *store = NULL;
+
+#ifndef HAVE_CAIRO
+	SECTION("storage/initialise", "should return NULL") {
+		start_capture();
+		REQUIRE(init_storage_backend("composite:{") == NULL);
+		std::tie(err_log_lines, out_log_lines) = end_capture();
+
+		found = err_log_lines.find("init_storage_ro_coposite: Support for compositing storage has not been compiled into this program");
+		REQUIRE(found > -1);
+	}
+#endif
+}
+
 TEST_CASE("ro_http_proxy storage-backend", "RO HTTP Proxy Tile storage backend")
 {
+	int found;
+	std::string err_log_lines, out_log_lines;
+	struct storage_backend *store = NULL;
+
+#ifdef HAVE_LIBCURL
 	SECTION("storage/initialise", "should return 1") {
 		struct storage_backend *store = NULL;
 
@@ -1216,6 +1239,16 @@ TEST_CASE("ro_http_proxy storage-backend", "RO HTTP Proxy Tile storage backend")
 
 		store->close_storage(store);
 	}
+#else
+	SECTION("storage/initialise", "should return NULL") {
+		start_capture();
+		REQUIRE(init_storage_backend("ro_http_proxy://") == NULL);
+		std::tie(err_log_lines, out_log_lines) = end_capture();
+
+		found = err_log_lines.find("init_storage_ro_http_proxy: Support for curl and therefore the http proxy storage has not been compiled into this program");
+		REQUIRE(found > -1);
+	}
+#endif
 }
 
 TEST_CASE("projections", "Test projections")


### PR DESCRIPTION
`libcurl` & `libcairo` are also optional and their usage can now be optionally disabled (along with `libmemcached` & `librados`.)