### PR TITLE
Allow linking alternate memory management implementations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,8 @@ set(USE_CAIRO ON CACHE BOOL "Add cairo support if available (for `store_ro_compo
 set(USE_CURL ON CACHE BOOL "Add curl support if available (for `store_ro_http_proxy.c` backend)")
 set(USE_MEMCACHED ON CACHE BOOL "Add memcached support if available (for `store_memcached.c` backend)")
 set(USE_RADOS ON CACHE BOOL "Add rados support if available (for `store_rados.c` backend)")
-
-set(MALLOC_LIB "glib" CACHE STRING "Memory Management Library for `renderd`")
-set_property(CACHE MALLOC_LIB PROPERTY STRINGS glib jemalloc tcmalloc)
+set(MALLOC_LIB "libc" CACHE STRING "Memory Management Library for `renderd`")
+set_property(CACHE MALLOC_LIB PROPERTY STRINGS "libc" "jemalloc" "mimalloc" "tcmalloc")
 
 #-----------------------------------------------------------------------------
 #
@@ -47,19 +46,6 @@ include(GNUInstallDirs)
 # Packages
 find_package(ICU REQUIRED uc)
 find_package(Threads REQUIRED)
-
-if (${MALLOC_LIB} STREQUAL "jemalloc")
-  # Switch to jemalloc (http://jemalloc.net) as the malloc/free
-  # implementation in renderd.
-  # Should address https://github.com/openstreetmap/mod_tile/issues/181
-  find_package(PkgConfig REQUIRED)
-  pkg_search_module(JEMALLOC REQUIRED jemalloc)
-elseif (${MALLOC_LIB} STREQUAL "tcmalloc")
-  # Switch to tcmalloc (https://github.com/google/tcmalloc)
-  # as the malloc/free implementation in renderd.
-  find_package(PkgConfig REQUIRED)
-  pkg_search_module(TCMALLOC REQUIRED libtcmalloc)
-endif()
 
 find_package(APR REQUIRED)
 find_package(GLIB 2.50 REQUIRED)
@@ -104,6 +90,20 @@ include(CheckLibraryExists)
 if(NOT HAVE_POW)
   check_library_exists(m pow "" HAVE_LIB_M)
   find_library(MATH_LIBRARY m REQUIRED)
+endif()
+
+if(NOT MALLOC_LIB STREQUAL "libc")
+  message(STATUS "Using '${MALLOC_LIB}' for memory managment")
+  if(MALLOC_LIB STREQUAL "jemalloc")
+    # jemalloc (http://jemalloc.net)
+    find_library(MALLOC_LIBRARY jemalloc REQUIRED)
+  elseif(MALLOC_LIB STREQUAL "mimalloc")
+    # mimalloc (https://github.com/microsoft/mimalloc)
+    find_library(MALLOC_LIBRARY mimalloc REQUIRED)
+  elseif(MALLOC_LIB STREQUAL "tcmalloc")
+    # tcmalloc (https://github.com/google/tcmalloc)
+    find_library(MALLOC_LIBRARY tcmalloc REQUIRED)
+  endif()
 endif()
 
 #-----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,13 @@ include(GNUInstallDirs)
 find_package(ICU REQUIRED uc)
 find_package(Threads REQUIRED)
 
+# Switch to jemalloc (http://jemalloc.net) as the malloc/free
+# implementation in renderd.
+# Should address https://github.com/openstreetmap/mod_tile/issues/181
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(JEMALLOC jemalloc)
+pkg_search_module(JEMALLOC REQUIRED jemalloc)
+
 find_package(APR REQUIRED)
 find_package(GLIB 2.50 REQUIRED)
 find_package(HTTPD 2.4 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ set(USE_CURL ON CACHE BOOL "Add curl support if available (for `store_ro_http_pr
 set(USE_MEMCACHED ON CACHE BOOL "Add memcached support if available (for `store_memcached.c` backend)")
 set(USE_RADOS ON CACHE BOOL "Add rados support if available (for `store_rados.c` backend)")
 
+set(MALLOC_LIB "glib" CACHE STRING "Memory Management Library for `renderd`")
+set_property(CACHE MALLOC_LIB PROPERTY STRINGS glib jemalloc tcmalloc)
+
 #-----------------------------------------------------------------------------
 #
 #  Find external dependencies
@@ -45,12 +48,18 @@ include(GNUInstallDirs)
 find_package(ICU REQUIRED uc)
 find_package(Threads REQUIRED)
 
-# Switch to jemalloc (http://jemalloc.net) as the malloc/free
-# implementation in renderd.
-# Should address https://github.com/openstreetmap/mod_tile/issues/181
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(JEMALLOC jemalloc)
-pkg_search_module(JEMALLOC REQUIRED jemalloc)
+if (${MALLOC_LIB} STREQUAL "jemalloc")
+  # Switch to jemalloc (http://jemalloc.net) as the malloc/free
+  # implementation in renderd.
+  # Should address https://github.com/openstreetmap/mod_tile/issues/181
+  find_package(PkgConfig REQUIRED)
+  pkg_search_module(JEMALLOC REQUIRED jemalloc)
+elseif (${MALLOC_LIB} STREQUAL "tcmalloc")
+  # Switch to tcmalloc (https://github.com/google/tcmalloc)
+  # as the malloc/free implementation in renderd.
+  find_package(PkgConfig REQUIRED)
+  pkg_search_module(TCMALLOC REQUIRED libtcmalloc)
+endif()
 
 find_package(APR REQUIRED)
 find_package(GLIB 2.50 REQUIRED)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,7 +179,9 @@ set(renderd_SRCS
   renderd.c
   request_queue.c
 )
+# JEMALLOC libraries should come *before* the GLIB libraries.
 set(renderd_LIBS
+  ${JEMALLOC_LIBRARIES}
   ${ICU_LIBRARIES}
   ${LIBMAPNIK_LIBRARIES}
   ${RENDER_LIBRARIES}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -41,7 +41,6 @@ set(RENDER_LIBRARIES
   ${COMMON_LIBRARIES}
   ${INIPARSER_LIBRARIES}
   ${MATH_LIBRARY}
-  Threads::Threads
 )
 
 set(STORE_SRCS
@@ -60,6 +59,11 @@ set(STORE_LIBRARIES
   ${LIBMEMCACHED_LIBRARIES}
   ${LIBRADOS_LIBRARIES}
 )
+
+if(NOT MALLOC_LIB STREQUAL "libc")
+  message(STATUS "Prepending '${MALLOC_LIBRARY}' to RENDER_LIBRARIES")
+  list(PREPEND RENDER_LIBRARIES ${MALLOC_LIBRARY})
+endif()
 
 #-----------------------------------------------------------------------------
 #
@@ -179,26 +183,12 @@ set(renderd_SRCS
   renderd.c
   request_queue.c
 )
-
 set(renderd_LIBS
   ${ICU_LIBRARIES}
   ${LIBMAPNIK_LIBRARIES}
   ${RENDER_LIBRARIES}
   ${STORE_LIBRARIES}
 )
-
-if ("${MALLOC_LIB}" STREQUAL "jemalloc")
-  message(STATUS "Using 'jemalloc' for memory management")
-  # JEMALLOC libraries should come *before* the GLIB libraries.
-  list(PREPEND renderd_LIBS ${JEMALLOC_LIBRARIES})
-elseif ("${MALLOC_LIB}" STREQUAL "tcmalloc")
-  message(STATUS "Using 'tcmalloc' for memory management")
-  # TCMALLOC libraries should come *before* the GLIB libraries.
-  list(PREPEND renderd_LIBS ${TCMALLOC_LIBRARIES})
-else()
-  message(STATUS "Using 'glib' for memory managment")
-endif()
-
 add_executable(renderd ${renderd_SRCS})
 target_link_libraries(renderd ${renderd_LIBS})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,14 +179,26 @@ set(renderd_SRCS
   renderd.c
   request_queue.c
 )
-# JEMALLOC libraries should come *before* the GLIB libraries.
+
 set(renderd_LIBS
-  ${JEMALLOC_LIBRARIES}
   ${ICU_LIBRARIES}
   ${LIBMAPNIK_LIBRARIES}
   ${RENDER_LIBRARIES}
   ${STORE_LIBRARIES}
 )
+
+if ("${MALLOC_LIB}" STREQUAL "jemalloc")
+  message(STATUS "Using 'jemalloc' for memory management")
+  # JEMALLOC libraries should come *before* the GLIB libraries.
+  list(PREPEND renderd_LIBS ${JEMALLOC_LIBRARIES})
+elseif ("${MALLOC_LIB}" STREQUAL "tcmalloc")
+  message(STATUS "Using 'tcmalloc' for memory management")
+  # TCMALLOC libraries should come *before* the GLIB libraries.
+  list(PREPEND renderd_LIBS ${TCMALLOC_LIBRARIES})
+else()
+  message(STATUS "Using 'glib' for memory managment")
+endif()
+
 add_executable(renderd ${renderd_SRCS})
 target_link_libraries(renderd ${renderd_LIBS})
 


### PR DESCRIPTION
With new `CMake CACHE` entry `MALLOC_LIB`, supporting the following values:
* `libc` (default): Use the system's implementation
* `jemalloc`: Use [jemalloc](http://jemalloc.net)
* `mimalloc`: Use [mimalloc](https://github.com/microsoft/mimalloc)
* `tcmalloc`: Use [tcmalloc](https://github.com/google/tcmalloc)