### PR TITLE
Fedora rawhide requires mapnik-static (now that it provides Mapnik v4.0.0)

### DIFF
--- a/.github/actions/dependencies/install/action.yml
+++ b/.github/actions/dependencies/install/action.yml
@@ -43,6 +43,7 @@ inputs:
       libmemcached-devel
       librados-devel
       mapnik-devel
+      mapnik-static
       sqlite-devel
   fedora-test-dependencies:
     default: >-

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -23,6 +23,7 @@ RUN --mount=id=fedora:${fedora_version}-/var/cache/dnf,target=/var/cache/dnf,typ
       libmemcached-devel \
       librados-devel \
       mapnik-devel \
+      mapnik-static \
       procps
 
 ## Build, Test & Install `mod_tile`

--- a/docs/build/building_on_fedora.md
+++ b/docs/build/building_on_fedora.md
@@ -28,7 +28,8 @@ sudo dnf --assumeyes --setopt=install_weak_deps=False install \
   libcurl-devel \
   libmemcached-devel \
   librados-devel \
-  mapnik-devel
+  mapnik-devel \
+  mapnik-static
 
 # Download, Build, Test & Install `mod_tile`
 export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)


### PR DESCRIPTION
It contains libraries now referenced by `pkg-config` and `mod_tile` uses only `pkg-config` for `Mapnik >= v4.0.0`.