### PR TITLE
Use anonymous shared memory segments for `mod_tile.so`

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -152,7 +152,6 @@ jobs:
       INSTALL_PREFIX: /usr/local
       INSTALL_RUNSTATEDIR: /var/run
       LDFLAGS: -undefined dynamic_lookup
-      TEST_PARALLEL_LEVEL: 1
     name: >-
       ${{ matrix.os }}
       (${{ matrix.build_system }})

--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -1756,8 +1756,7 @@ static int mod_tile_post_config(apr_pool_t *pconf, apr_pool_t *plog,
 	 * depending on OS and locking mechanism of choice, the file
 	 * may or may not be actually created.
 	 */
-	mutexfilename = apr_psprintf(pconf, "/tmp/httpd_mutex.%ld",
-				     (long int)getpid());
+	mutexfilename = apr_psprintf(pconf, "%s/httpd_mutex.%ld", P_tmpdir, (long int)getpid());
 
 	rs = apr_global_mutex_create(&stats_mutex, (const char *)mutexfilename,
 				     APR_LOCK_DEFAULT, pconf);
@@ -1786,8 +1785,7 @@ static int mod_tile_post_config(apr_pool_t *pconf, apr_pool_t *plog,
 	 * depending on OS and locking mechanism of choice, the file
 	 * may or may not be actually created.
 	 */
-	mutexfilename = apr_psprintf(pconf, "/tmp/httpd_mutex_delay.%ld",
-				     (long int)getpid());
+	mutexfilename = apr_psprintf(pconf, "%s/httpd_mutex_delay.%ld", P_tmpdir, (long int)getpid());
 
 	rs = apr_global_mutex_create(&delaypool_mutex, (const char *)mutexfilename,
 				     APR_LOCK_DEFAULT, pconf);


### PR DESCRIPTION
Rather than named shared memory segments (see [here](https://apr.apache.org/docs/apr/trunk/group__apr__shm.html#gac370c4943c22505ce2b0d57c51805480)).

Fixes tests on `macOS` unable to run in parallel, which was likely an indicator of a greater issue with `macOS` builds