### PR TITLE
Enable `SO_REUSE{ADDR,PORT}` for `renderd` TCP/IP server sockets

### DIFF
--- a/src/renderd.c
+++ b/src/renderd.c
@@ -494,6 +494,8 @@ int server_socket_init(renderd_config *sConfig)
 	int fd;
 
 	if (sConfig->ipport > 0) {
+		const int enable = 1;
+
 		g_logger(G_LOG_LEVEL_INFO, "Initialising TCP/IP server socket on %s:%i",
 			 sConfig->iphostname, sConfig->ipport);
 		fd = socket(PF_INET6, SOCK_STREAM, 0);
@@ -501,6 +503,18 @@ int server_socket_init(renderd_config *sConfig)
 		if (fd < 0) {
 			g_logger(G_LOG_LEVEL_CRITICAL, "failed to create IP socket");
 			exit(2);
+		}
+
+		if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &enable, sizeof(enable)) < 0) {
+			g_logger(G_LOG_LEVEL_CRITICAL, "setsockopt SO_REUSEADDR failed for: %s:%i",
+				 sConfig->iphostname, sConfig->ipport);
+			exit(3);
+		}
+
+		if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &enable, sizeof(enable)) < 0) {
+			g_logger(G_LOG_LEVEL_CRITICAL, "setsockopt SO_REUSEPORT failed for: %s:%i",
+				 sConfig->iphostname, sConfig->ipport);
+			exit(3);
 		}
 
 		bzero(&addrI, sizeof(addrI));


### PR DESCRIPTION
Otherwise `renderd` processes configured to use TCP/IP server sockets may need to wait until the address and/or port are released before restarting under certain circumstances (especially an ungraceful termination).