### PR TITLE
Add `Origin` header test for CORS not being set

### DIFF
--- a/src/mod_tile.c
+++ b/src/mod_tile.c
@@ -1871,6 +1871,7 @@ static const char *_add_tile_config(cmd_parms *cmd,
 
 	int attribution_len = strnlen(attribution, PATH_MAX);
 	int baseuri_len = strnlen(baseuri, PATH_MAX);
+	int cors_len = strnlen(cors, PATH_MAX);
 	int hostnames_len = 1;
 	int server_alias_len = strnlen(server_alias, PATH_MAX);
 	int tile_dir_len = strnlen(tile_dir, PATH_MAX);
@@ -1885,6 +1886,11 @@ static const char *_add_tile_config(cmd_parms *cmd,
 		baseuri = apr_pstrdup(cmd->pool, "/");
 	} else if (baseuri[baseuri_len - 1] != '/') {
 		baseuri = apr_psprintf(cmd->pool, "%s/", baseuri);
+	}
+
+	// If cors is empty, set it to NULL
+	if (cors_len == 0) {
+		cors = NULL;
 	}
 
 	// If server_alias is set, increment hostnames_len
@@ -1954,7 +1960,7 @@ static const char *_add_tile_config(cmd_parms *cmd,
 
 static const char *add_tile_mime_config(cmd_parms *cmd, void *mconfig, const char *baseuri, const char *name, const char *fileExtension)
 {
-	char *cors = NULL;
+	char *cors = "";
 	char *mimeType = "image/png";
 
 	if (strcmp(fileExtension, "js") == 0) {
@@ -2010,7 +2016,7 @@ static const char *add_tile_config(cmd_parms *cmd, void *mconfig, int argc, char
 		return "AddTileConfig error, the configured zoom level lies outside of the range supported by this server";
 	}
 
-	return _add_tile_config(cmd, baseuri, name, minzoom, maxzoom, 1, 1, fileExtension, mimeType, "", "", "", NULL, tile_dir, 0);
+	return _add_tile_config(cmd, baseuri, name, minzoom, maxzoom, 1, 1, fileExtension, mimeType, "", "", "", "", tile_dir, 0);
 }
 
 static const char *load_tile_config(cmd_parms *cmd, void *mconfig, const char *config_file_name)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -889,6 +889,76 @@ foreach(STORAGE_BACKEND_INDEX RANGE ${STORAGE_BACKENDS_LENGTH})
     )
 
     # Generate URL path for tiles
+    set(TILE_URL_PATH "/tiles/${DEFAULT_MAP_NAME}/5/5/5.png")
+    # Generate tile URLs
+    set(HTTPD0_URL "http://${HTTPD0_HOST}:${HTTPD0_PORT}${TILE_URL_PATH}")
+    set(HTTPD1_URL "http://${HTTPD1_HOST}:${HTTPD1_PORT}${TILE_URL_PATH}")
+    add_test(NAME cors_empty_${STORAGE_BACKEND}
+      COMMAND ${BASH} -c "
+        RESPONSE_CODE_CMD=\"${CURL_CMD} --write-out %{http_code} --output /dev/null\"
+        RESPONSE_CODE=$(\${RESPONSE_CODE_CMD} ${HTTPD0_URL})
+        echo \"Response code: '\${RESPONSE_CODE}'\"
+        if [ \"\${RESPONSE_CODE}\" != \"200\" ]; then
+          exit 1;
+        fi
+        RESPONSE_CODE=$(\${RESPONSE_CODE_CMD} ${HTTPD1_URL})
+        echo \"Response code: '\${RESPONSE_CODE}'\"
+        if [ \"\${RESPONSE_CODE}\" != \"200\" ]; then
+          exit 1;
+        fi
+        RESPONSE_CODE=$(\${RESPONSE_CODE_CMD} --header \"Origin: example.com\" ${HTTPD0_URL})
+        echo \"Response code: '\${RESPONSE_CODE}'\"
+        if [ \"\${RESPONSE_CODE}\" != \"200\" ]; then
+          exit 1;
+        fi
+        RESPONSE_CODE=$(\${RESPONSE_CODE_CMD} --header \"Origin: example.com\" ${HTTPD1_URL})
+        echo \"Response code: '\${RESPONSE_CODE}'\"
+        if [ \"\${RESPONSE_CODE}\" != \"200\" ]; then
+          exit 1;
+        fi
+      "
+      WORKING_DIRECTORY tests
+    )
+    set_tests_properties(cors_empty_${STORAGE_BACKEND} PROPERTIES
+      FIXTURES_REQUIRED services_started_${STORAGE_BACKEND}
+    )
+
+    # Generate URL path for tiles
+    set(TILE_URL_PATH "/good_add_tile_config/${TILE_ZXY}.png")
+    # Generate tile URLs
+    set(HTTPD0_URL "http://${HTTPD0_HOST}:${HTTPD0_PORT}${TILE_URL_PATH}")
+    set(HTTPD1_URL "http://${HTTPD1_HOST}:${HTTPD1_PORT}${TILE_URL_PATH}")
+    add_test(NAME cors_empty_${STORAGE_BACKEND}_add_tile_config
+      COMMAND ${BASH} -c "
+        RESPONSE_CODE_CMD=\"${CURL_CMD} --write-out %{http_code} --output /dev/null\"
+        RESPONSE_CODE=$(\${RESPONSE_CODE_CMD} ${HTTPD0_URL})
+        echo \"Response code: '\${RESPONSE_CODE}'\"
+        if [ \"\${RESPONSE_CODE}\" != \"200\" ]; then
+          exit 1;
+        fi
+        RESPONSE_CODE=$(\${RESPONSE_CODE_CMD} ${HTTPD1_URL})
+        echo \"Response code: '\${RESPONSE_CODE}'\"
+        if [ \"\${RESPONSE_CODE}\" != \"200\" ]; then
+          exit 1;
+        fi
+        RESPONSE_CODE=$(\${RESPONSE_CODE_CMD} --header \"Origin: example.com\" ${HTTPD0_URL})
+        echo \"Response code: '\${RESPONSE_CODE}'\"
+        if [ \"\${RESPONSE_CODE}\" != \"200\" ]; then
+          exit 1;
+        fi
+        RESPONSE_CODE=$(\${RESPONSE_CODE_CMD} --header \"Origin: example.com\" ${HTTPD1_URL})
+        echo \"Response code: '\${RESPONSE_CODE}'\"
+        if [ \"\${RESPONSE_CODE}\" != \"200\" ]; then
+          exit 1;
+        fi
+      "
+      WORKING_DIRECTORY tests
+    )
+    set_tests_properties(cors_empty_${STORAGE_BACKEND}_add_tile_config PROPERTIES
+      FIXTURES_REQUIRED services_started_${STORAGE_BACKEND}
+    )
+
+    # Generate URL path for tiles
     set(TILE_URL_PATH "/tiles/cors_all/${TILE_ZXY}.png")
     # Generate tile URLs
     set(HTTPD0_URL "http://${HTTPD0_HOST}:${HTTPD0_PORT}${TILE_URL_PATH}")


### PR DESCRIPTION
Also moved `cors = NULL` fix from #479 into `_add_tile_config` instead as that fix only applied to configs added via `AddTileConfig` in `httpd.conf` files, not all methods.