### PR TITLE
CI pipeline test fixes

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -108,8 +108,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - "debian:12"
-          - "ubuntu:24.04"
+          - "debian:unstable"
+          - "ubuntu:devel"
         build_system:
           - CMake
         compiler:
@@ -141,6 +141,8 @@ jobs:
         uses: ./.github/actions/coverage
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          genhtml-extra-options: --keep-going --ignore-errors inconsistent
+          lcov-extra-options: --keep-going --ignore-errors inconsistent
 
       - name: Package `mod_tile`
         uses: ./.github/actions/cmake/package

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -204,8 +204,8 @@ jobs:
         uses: ./.github/actions/coverage
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
-          genhtml-extra-options: --keep-going --ignore-errors count,inconsistent,range
-          lcov-extra-options: --keep-going --ignore-errors count,inconsistent,range
+          genhtml-extra-options: --keep-going --ignore-errors category,count,format,inconsistent,range
+          lcov-extra-options: --keep-going --ignore-errors count,format,inconsistent,range
         if: matrix.os != 'macos-12'
 
       - name: Package `mod_tile`


### PR DESCRIPTION
- Fix failing `Mapnik Latest` tests:
  - `Debian 12`'s [boost](https://github.com/mapnik/mapnik/blob/master/CHANGELOG.md#mapnik-405) is too old for `Mapnik` >= `v4.0.5`
- Fix failing `macOS` coverage
  - `format` & `category` errors have been popping up recently