### PR TITLE
Disallow map section URI paths which are parents of subsequent map section URI paths

### DIFF
--- a/etc/apache2/renderd-example-map.conf
+++ b/etc/apache2/renderd-example-map.conf
@@ -161,5 +161,5 @@ Listen 8081
     # Off = a 404 is returned for that url instead.
     # Default: On
     #ModTileEnableDirtyURL Off
-
+    LogLevel debug
 </VirtualHost>


### PR DESCRIPTION
This has unexpected effects for `map` section `URI` values which are parent paths of subsequent `map` section URIs.

E.g. for:
```ini
[map0]
uri=/map1/

[map1]
uri=/map1/1/

[map2]
uri=/map2/2/
```
Only `map0` and `map2` would be served as the `uri` for `map1` is a path under the `uri` for `map0`.

Also, for:

```ini
[map0]
uri=/ # or no uri specification at all

[map1]
uri=/map1/1/

[map2]
uri=/map2/2/
```
Only `map0`  would be served as the `uri` for both `map1` and `map2` are paths under the `uri` for `map0`.

This pull request stops these from being allowed in `renderd.conf` files.

Resolves #27 